### PR TITLE
API usage examples

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -312,9 +312,8 @@ Preconnection.Listen()
 
 Preconnection -> ConnectionReceived<Connection>
 
-// Only receive complete messages:
-// minIncompleteLength and maxLength are infinite by default
-Connection.Receive(minIncompleteLength, maxLength)
+// Only receive complete messages
+Connection.Receive()
 
 Connection -> Received(messageDataRequest, messageContext)
 
@@ -359,9 +358,8 @@ Connection -> Ready<>
 
 Connection.Send(messageDataRequest)
 
-// Only receive complete messages:
-// minIncompleteLength and maxLength are infinite by default
-Connection.Receive(minIncompleteLength, maxLength)
+// Only receive complete messages
+Connection.Receive()
 
 Connection -> Received(messageDataResponse, messageContext)
 
@@ -406,9 +404,8 @@ Preconnection -> RendezvousDone<Connection>
 
 Connection.Send(messageDataRequest)
 
-// Only receive complete messages:
-// minIncompleteLength and maxLength are infinite by default
-Connection.Receive(minIncompleteLength, maxLength)
+// Only receive complete messages
+Connection.Receive()
 
 Connection -> Received(messageDataResponse, messageContext)
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -261,14 +261,15 @@ described in {{I-D.ietf-taps-arch}}.
 ## Usage Examples
 
 The following usage examples illustrate how an application might use a
-Transport Services Interface to
+Transport Services Interface to:
 
-- Act as a server: Listen for incoming connections, receive a request, and send
-  a response, see {{server-example}}.
-- Act as a client: Connect to a remote endpoint, send a request, and receive a
-  response, see {{client-example}}.
-- Act as a peer: Connect to a remote endpoint using Rendezvous, send a Message,
-  and receive a Message, see {{peer-example}}.
+- Act as a server, by listening for incoming connections, receiving requests,
+  and sending responses, see {{server-example}}.
+- Act as a client, by connecting to a remote endpoint using Initiate, sending
+  requests, and receiving responses, see {{client-example}}.
+- Act as a peer, by connecting to a remote endpoint using Rendezvous while
+  simultaneously waiting for incoming Connections, sending Messages, and
+  receiving Messages, see {{peer-example}}.
 
 The examples in this section presume that a transport protocol is available
 between the endpoints which provides Reliable Data Transfer, Preservation of
@@ -290,13 +291,12 @@ using the Transport Services Interface, receive a request, and send a response.
 
 ~~~
 LocalSpecifier := NewLocalEndpoint()
-LocalSpecifier.WithInterface("en0")
+LocalSpecifier.WithInterface("any")
 LocalSpecifier.WithService("https")
 
 TransportProperties := NewTransportProperties()
-TransportProperties.Require(reliability)
-TransportProperties.Require(preserve-order)
 TransportProperties.Require(preserve-msg-boundaries)
+// Reliable Data Transfer and Preserve Order are Required by default
 
 SecurityParameters := NewSecurityParameters()
 SecurityParameters.AddIdentity(identity)
@@ -312,10 +312,8 @@ Preconnection.Listen()
 
 Preconnection -> ConnectionReceived<Connection>
 
-// Only receive complete messages
-minIncompleteLength = Infinite
-maxLength = Infinite
-
+// Only receive complete messages:
+// minIncompleteLength and maxLength are infinite by default
 Connection.Receive(minIncompleteLength, maxLength)
 
 Connection -> Received(messageDataRequest, messageContext)
@@ -340,9 +338,8 @@ RemoteSpecifier.WithHostname("example.com")
 RemoteSpecifier.WithService("https")
 
 TransportProperties := NewTransportProperties()
-TransportProperties.Require(reliability)
-TransportProperties.Require(preserve-order)
 TransportProperties.Require(preserve-msg-boundaries)
+// Reliable Data Transfer and Preserve Order are Required by default
 
 SecurityParameters := NewSecurityParameters()
 TrustCallback := New Callback({
@@ -362,9 +359,8 @@ Connection -> Ready<>
 
 Connection.Send(messageDataRequest)
 
-// Only receive complete messages
-minIncompleteLength = Infinite
-maxLength = Infinite
+// Only receive complete messages:
+// minIncompleteLength and maxLength are infinite by default
 Connection.Receive(minIncompleteLength, maxLength)
 
 Connection -> Received(messageDataResponse, messageContext)
@@ -386,9 +382,8 @@ RemoteSpecifier.WithHostname("example.com")
 RemoteSpecifier.WithPort(9877)
 
 TransportProperties := NewTransportProperties()
-TransportProperties.Require(reliability)
-TransportProperties.Require(preserve-order)
 TransportProperties.Require(preserve-msg-boundaries)
+// Reliable Data Transfer and Preserve Order are Required by default
 
 SecurityParameters := NewSecurityParameters()
 SecurityParameters.AddIdentity(identity)
@@ -411,9 +406,8 @@ Preconnection -> RendezvousDone<Connection>
 
 Connection.Send(messageDataRequest)
 
-// Only receive complete messages
-minIncompleteLength = Infinite
-maxLength = Infinite
+// Only receive complete messages:
+// minIncompleteLength and maxLength are infinite by default
 Connection.Receive(minIncompleteLength, maxLength)
 
 Connection -> Received(messageDataResponse, messageContext)
@@ -482,7 +476,6 @@ following recommendations:
   exclusive of appendices, even if said implementation is a non-operation, e.g.
   because transport protocols implementing a given Property are not available on
   the platform.
-
 
 # Pre-Establishment Phase {#pre-establishment}
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -320,6 +320,171 @@ following recommendations:
   because transport protocols implementing a given Property are not available on
   the platform.
 
+## Usage Examples
+
+The following usage examples illustrate how an application might use a
+Transport Services Interface to
+
+- Act as a server: Listen for incoming connections, receive a request, and send
+  a response, see {{server-example}}.
+- Act as a client: Connect to a remote endpoint, send a request, and receive a
+  response, see {{client-example}}.
+- Act as a peer: Connect to a remote endpoint using Rendezvous, send a Message,
+  and receive a Message, see {{peer-example}}.
+
+The examples in this section presume that a transport protocol is available
+between the endpoints which provides Reliable Data Transfer, Preservation of
+data ordering, and Preservation of Message Boundaries. In this case, the
+application can choose to receive only complete messages.
+
+If none of the available transport protocols provides Preservation of Message
+Boundaries, but there is a transport protocol which provides a reliable ordered
+octet stream transport, an application may receive this octet stream as partial
+messages and parse it into application-layer Messages itself.  Alternatively,
+an application may provide a Deframer, which is a function that transforms an
+octet stream into a sequence of Messages, see {{receive-framing}}.
+
+
+### Server Example
+
+This is an example of how an application might listen for incoming Connections
+using the Transport Services Interface, receive a request, and send a response.
+
+~~~
+LocalSpecifier := NewLocalEndpoint()
+LocalSpecifier.WithInterface("en0")
+LocalSpecifier.WithService("https")
+
+TransportProperties := NewTransportProperties()
+TransportProperties.Require(reliability)
+TransportProperties.Require(preserve-order)
+TransportProperties.Require(preserve-msg-boundaries)
+
+SecurityParameters := NewSecurityParameters()
+SecurityParameters.AddIdentity(identity)
+SecurityParameters.AddPrivateKey(privateKey, publicKey)
+
+// Specifying a remote endpoint is optional when using Listen()
+Preconnection := NewPreconnection(LocalSpecifier,
+                                  None,
+                                  TransportProperties,
+                                  SecurityParameters)
+
+Preconnection.Listen()
+
+Preconnection -> ConnectionReceived<Connection>
+
+// Only receive complete messages
+minIncompleteLength = Infinite
+maxLength = Infinite
+
+Connection.Receive(minIncompleteLength, maxLength)
+
+Connection -> Received(messageDataRequest, messageContext)
+
+Connection.Send(messageDataResponse)
+
+Connection.Close()
+
+// Stop listening for incoming connections
+Preconnection.Stop()
+~~~
+
+
+### Client Example
+
+This is an example of how an application might connect to a remote application
+using the Transport Services Interface, send a request, and receive a response.
+
+~~~
+RemoteSpecifier := NewRemoteEndpoint()
+RemoteSpecifier.WithHostname("example.com")
+RemoteSpecifier.WithService("https")
+
+TransportProperties := NewTransportProperties()
+TransportProperties.Require(reliability)
+TransportProperties.Require(preserve-order)
+TransportProperties.Require(preserve-msg-boundaries)
+
+SecurityParameters := NewSecurityParameters()
+TrustCallback := New Callback({
+  // Verify identity of the remote endpoint, return the result
+})
+SecurityParameters.SetTrustVerificationCallback(trustCallback)
+
+// Specifying a local endpoint is optional when using Initiate()
+Preconnection := NewPreconnection(None,
+                                  RemoteSpecifier,
+                                  TransportPreperties,
+                                  SecurityParameters)
+
+Connection := Preconnection.Initiate()
+
+Connection -> Ready<>
+
+Connection.Send(messageDataRequest)
+
+// Only receive complete messages
+minIncompleteLength = Infinite
+maxLength = Infinite
+Connection.Receive(minIncompleteLength, maxLength)
+
+Connection -> Received(messageDataResponse, messageContext)
+
+Connection.Close()
+~~~
+
+### Peer Example
+
+This is an example of how an application might establish a connection with a
+peer.
+
+~~~
+LocalSpecifier := NewLocalEndpoint()
+LocalSpecifier.WithPort(9876)
+
+RemoteSpecifier := NewRemoteEndpoint()
+RemoteSpecifier.WithHostname("example.com")
+RemoteSpecifier.WithPort(9877)
+
+TransportProperties := NewTransportProperties()
+TransportProperties.Require(reliability)
+TransportProperties.Require(preserve-order)
+TransportProperties.Require(preserve-msg-boundaries)
+
+SecurityParameters := NewSecurityParameters()
+SecurityParameters.AddIdentity(identity)
+SecurityParameters.AddPrivateKey(privateKey, publicKey)
+
+TrustCallback := New Callback({
+  // Verify identity of the remote endpoint, return the result
+})
+SecurityParameters.SetTrustVerificationCallback(trustCallback)
+
+// Both local and remote endpoint must be specified
+Preconnection := NewPreconnection(LocalSpecifier,
+                                  RemoteSpecifier,
+                                  TransportPreperties,
+                                  SecurityParameters)
+
+Preconnection.Rendezvous()
+
+Preconnection -> RendezvousDone<Connection>
+
+Connection.Send(messageDataRequest)
+
+// Only receive complete messages
+minIncompleteLength = Infinite
+maxLength = Infinite
+Connection.Receive(minIncompleteLength, maxLength)
+
+Connection -> Received(messageDataResponse, messageContext)
+
+Connection.Close()
+~~~
+
+
+
 # Pre-Establishment Phase {#pre-establishment}
 
 The pre-establishment phase allows applications to specify properties for


### PR DESCRIPTION
This PR provides usage examples of our abstract interface, to address #247.

The examples show how an application might use Listen(), Initiate(), and Rendezvous(), send a Message, and receive a Message.
There is some redundancy between these examples, and I introduces some subtle differences to make them plausible, e.g., the "server" provides its identity, and the "client" verifies the other endpoint's identity using a trust callback.

Overall the section became rather long. Should we instead just stick to one example, e.g., Initiate()? (Or Rendezvous() because it covers the most aspects? Or Initiate() but with all the aspects from Rendezvous()?)

Otherwise I'm particularly interested in feedback on the Rendezvous() example -- I think it's correct wrt the draft, but is there a "more plausible" port number, and should anything else be set there that is not in the Initiate() and Listen() examples?