### PR TITLE
Caching Boundaries using Connection Groups

### DIFF
--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -447,15 +447,17 @@ If two different Protocol Stacks can be safely swapped, or raced in parallel (se
 
 ### Separating Connection Groups {#groups}
 
-By default, all stored properties of the Implementation are shared within a process, such as cached protocol state, cached path state, and heuristics. This provides efficiency and convenience for the application, since the Transport System Implementation will be able to automatically optimize behavior.
+By default, all stored properties of the Implementation are shared within a process, such as cached protocol state, cached path state, and heuristics. This provides efficiency and convenience for the application, since the Transport System Implementation can automatically optimize behavior.
 
 There are several reasons, however, that an application might want to isolate some Connections within a single process. These reasons include:
 
-- Privacy concerns about re-using cached protocol state that can lead to linkability. Sensitive state may include TLS session resumption state {{RFC8446}} and HTTP cookies {{RFC6265}}.
+- Privacy concerns about re-using cached protocol state that can lead to linkability. Sensitive state may include TLS session state {{RFC8446}} and HTTP cookies {{RFC6265}}.
 - Privacy concerns about allowing Connections to multiplex together, which can tell a Remote Endpoint that all of the Connections are coming from the same application (for example, when Connections are multiplexed HTTP/2 or QUIC streams).
 - Performance concerns about Connections introducing head-of-line blocking due to multiplexing or needing to share state on a single thread.
 
-The Transport Services API SHOULD allow applications to explicitly define Connection Groups to force separation of Cached State and Protocol Stacks. The interface to specify these Groups can optionally expose fine-grained tuning for which properties and cached state is allowed to be shared with other Connections. For example, an application might want to allow sharing TCP Fast Open cookies across groups, but not TLS resumption state. 
+The Transport Services API SHOULD allow applications to explicitly define Connection Groups to force separation of Cached State and Protocol Stacks. For example, a web browser application might use separate Connection Groups for different tabs in the browser to decrease linkability.
+
+The interface to specify these Groups can optionally expose fine-grained tuning for which properties and cached state is allowed to be shared with other Connections. For example, an application might want to allow sharing TCP Fast Open cookies across groups, but not TLS session state.
 
 # IANA Considerations
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -403,7 +403,7 @@ This list of events that can be delivered to an application is not exhaustive, b
 
 The Transport System Implementation Concepts define the set of objects used internally to a system or library to implement the functionality needed to provide a transport service across a network, as required by the abstract interface.
 
-* Connection Group: A set of Connections that share properties. For multiplexing transport protocols, the Connection Group defines the set of Connections that can be multiplexed together. Groups can be defined implicitly by the Implementation, based on which properties are compatible. However, applications SHOULD be able to explicitly define Connection Groups, as discussed in {{groups}}.
+* Connection Group: A set of Connections that share properties and caches. For multiplexing transport protocols, only Connections within the same Connection Group are allowed be multiplexed together. Applications can use their explicitly defined Connection Groups to control caching boundaries, as discussed in {{groups}}.
 
 * Path: Represents an available set of properties that a local system can use to communicate with a remote system, such as routes, addresses, and physical and virtual network interfaces.
 
@@ -455,9 +455,9 @@ There are several reasons, however, that an application might want to isolate so
 - Privacy concerns about allowing Connections to multiplex together, which can tell a Remote Endpoint that all of the Connections are coming from the same application (for example, when Connections are multiplexed HTTP/2 or QUIC streams).
 - Performance concerns about Connections introducing head-of-line blocking due to multiplexing or needing to share state on a single thread.
 
-The Transport Services API SHOULD allow applications to explicitly define Connection Groups to force separation of Cached State and Protocol Stacks. For example, a web browser application might use separate Connection Groups for different tabs in the browser to decrease linkability.
+The Transport Services API SHOULD allow applications to explicitly define Connection Groups that force separation of Cached State and Protocol Stacks. For example, a web browser application might use Connection Groups with separate caches for different tabs in the browser to decrease linkability.
 
-The interface to specify these Groups can optionally expose fine-grained tuning for which properties and cached state is allowed to be shared with other Connections. For example, an application might want to allow sharing TCP Fast Open cookies across groups, but not TLS session state.
+The interface to specify these Groups MAY expose fine-grained tuning for which properties and cached state is allowed to be shared with other Connections. For example, an application might want to allow sharing TCP Fast Open cookies across groups, but not TLS session state.
 
 # IANA Considerations
 

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -89,7 +89,6 @@ normative:
 
 informative:
     I-D.ietf-quic-transport:
-    I-D.ietf-tls-tls13:
     NEAT-flow-mapping:
       title: Transparent Flow Mapping for NEAT (in Workshop on Future of Internet Transport (FIT 2017))
       authors:
@@ -508,7 +507,7 @@ If a Connection becomes finished before a requested Receive action can be satisf
 
 ## Handling of data for fast-open protocols {#fastopen}
 
-Several protocols allow sending higher-level protocol or application data within the first packet of their protocol establishment, such as TCP Fast Open {{!RFC7413}} and TLS 1.3 {{I-D.ietf-tls-tls13}}. This approach is referred to as sending Zero-RTT (0-RTT) data. This is a desirable property, but poses challenges to an implementation that uses racing during connection establishment.
+Several protocols allow sending higher-level protocol or application data within the first packet of their protocol establishment, such as TCP Fast Open {{!RFC7413}} and TLS 1.3 {{!RFC8446}}. This approach is referred to as sending Zero-RTT (0-RTT) data. This is a desirable property, but poses challenges to an implementation that uses racing during connection establishment.
 
 If the application has 0-RTT data to send in any protocol handshakes, it needs to provide this data before the handshakes have begun. When racing, this means that the data should be provided before the process of connection establishment has begun. If the application wants to send 0-RTT data, it must indicate this to the implementation by setting the Idempotent send parameter to true when sending the data. In general, 0-RTT data may be replayed (for example, if a TCP SYN contains data, and the SYN is retransmitted, the data will be retransmitted as well), but racing means that different leaf nodes have the opportunity to send the same data independently. If data is truly idempotent, this should be permissible.
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1482,7 +1482,7 @@ data transfer (before connection establishment has finished). This is useful if
 applications need to treat early data separately,
 e.g., if early data has different security properties than data sent after
 connection establishment. In the case of TLS 1.3, client early data can be replayed
-maliciously (see {{!I-D.ietf-tls-tls13}}). Thus, receivers may wish to perform additional
+maliciously (see {{!RFC8446}}). Thus, receivers may wish to perform additional
 checks for early data to ensure it is idempotent or not replayed. If TLS 1.3 is available
 and the recipient Message was sent as part of early data, the corresponding metadata carries
 a flag indicating as such. If early data is enabled, applications should check this metadata


### PR DESCRIPTION
Alternate proposal to address #45 (old PR was "Add CacheContext to architecture and API", #244)

- Define explicit Connection Groups as a way to define caching boundaries
- Update TLS 1.3 references to RFC 8446