### PR TITLE
Add Connection Pool Object

### DIFF
--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -344,7 +344,7 @@ The diagram below provides a high-level view of the actions taken during the lif
 
 * Listener: A Listener object accepts incoming transport protocol connections from remote systems and generates corresponding Connection objects. It is created from a Preconnection object that specifies the type of incoming connections it will accept.
 
-* Connection Pool: A Connection Pool hides a set of Connections and Listeners between equivalent Endpoints. When used as initiator pool, it automatically maps requests to established Connections or establishes Connections when necessary.  When used as responder pool, it automatically listens for connections and delivers messages received from these to the application.
+* Connection Pool: A Connection Pool hides a set of Connections and Listeners between equivalent Endpoints. When using an Requestor Pool, it automatically maps requests to established Connections or establishes Connections when necessary.  When using a Responder pool, it automatically listens for connections and delivers messages received from these to the application.
   
 ### Pre-Establishment {#preestablishment}
 


### PR DESCRIPTION
This PR adds a first proposal for Connection Pools to TAPS as discussed in Issue #266.

**This is an alternative to PR #298.**

Pooled Connections are only useful for request/response protocols like HTTP and serve the following purposes:
 - Provide a clean abstraction for HTTP/3 that is backward compatible to HTTP/0.9
 - Remove the motivation to map QUIC streams to Messages (by removing the drawback of complication HTTP/3 mapping when they are mapped to TAPS connections)
 - Allow Per-Request Path- and Endpoint Selection

See [my post on the mailing list](https://mailarchive.ietf.org/arch/msg/taps/u4imn1IKFBeSxwJRJK_HNwEoT98) for a more detailed description of this topic.