### PR TITLE
Add Pooled Connections

### DIFF
--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -185,6 +185,9 @@ Providing a message-based abstraction provides many benefits, such as:
 
 Allowing applications to interact with messages is backwards-compatible with existings protocols and APIs, as it does not change the wire format of any protocol. Instead, it gives the protocol stack additional information to allow it to make better use of modern transport services, while simplifying the application's role in parsing data.
 
+For request/response protocols like HTTP, that can be operated using several transport connections between equivalent endpoints or via multi-streaming connections the Transport Services API supports Connection Pools.
+These connection pools hide the connection management and provide a messages-only API that enables per-message endpoint and path selection.
+
 ## Flexibile Implementation
 
 Sockets, for protocols like TCP, are generally limited to connecting to a single address over a single interface. They also present a single stream to the application. Software layers built upon sockets often propagate this limitation of a single-address single-stream model. The Transport Services architecture is designed to handle multiple candidate endpoints, protocols, and paths; and support multipath and multistreaming protocols.
@@ -338,9 +341,12 @@ The diagram below provides a high-level view of the actions taken during the lif
 * Preconnection: A Preconnection object is a representation of a potential connection. It has state that describes parameters of a Connection that might exist in the future: the Local Endpoint from which that Connection will be established, the Remote Endpoint ({{preestablishment}}) to which it will connect, and Selection Properties ({{preestablishment}}) that influence the paths and protocols a Connection will use. A Preconnection can be fully specified and represent a single possible Connection, or it can be partially specified such that it represents a family of possible Connections. The Local Endpoint ({{preestablishment}}) MUST be specified if the Preconnection is used to Listen for incoming connections. The Local Endpoint is OPTIONAL if it is used to Initiate connections. The Remote Endpoint MUST be specified in the Preconnection is used to Initiate connections. The Remote Endpoint is OPTIONAL if it is used to Listen for incoming connections. The Local Endpoint and the Remote Endpoint MUST both be specified if a peer-to-peer Rendezvous is to occur based on the Preconnection.
   * Transport Properties: Transport Properties can be specified as part of a Preconnection to allow the application to configure the Transport System and express their requirements, prohibitions, and preferences. There are three kinds of Transport Properties: Selection Properties ({{preestablishment}}), Connection Properties ({{preestablishment}}), and Message Properties ({{datatransfer}}). Message Properties can also be specified during data transfer to affect specific Messages.
 
-* Connection: A Connection object represents an active transport protocol instance that can send and/or receive Messages between local and remote systems. It holds state pertaining to the underlying transport protocol instance and any ongoing data transfer. This represents, for example, an active connection in a connection-oriented protocol such as TCP, or a fully-specified 5-tuple for a connectionless protocol such as UDP.
+* Connection: A Connection object represents one or more active transport protocol instance that can send and/or receive Messages between local and remote systems. It holds state pertaining to the underlying transport protocol instance(s) and any ongoing data transfer(s).
+  This represents, for example, an active connection in a connection-oriented protocol such as TCP, or a fully-specified 5-tuple for a connectionless protocol such as UDP.
+  However, a connection can also represent a pool of transport protocol instance, for example, a bunch of TCP and QUIC connections to equivalent endpoints provided by a CDN, or a set of incoming connections that are saved the same way.
 
 * Listener: A Listener object accepts incoming transport protocol connections from remote systems and generates corresponding Connection objects. It is created from a Preconnection object that specifies the type of incoming connections it will accept.
+
   
 ### Pre-Establishment {#preestablishment}
 


### PR DESCRIPTION
This PR adds a first proposal for adding Pooled Connection support to TAPS as discussed in Issue #266. 

**This is an alternative to PR #295.**

Pooled Connections are only useful for request/response protocols like HTTP and serve the following purposes:
 - Provide a clean abstraction for HTTP/3 that is backward compatible to HTTP/0.9
 - Remove the motivation to map QUIC streams to Messages (by removing the drawback of complication HTTP/3 mapping when they are mapped to TAPS connections)
 - Allow Per-Request Path- and Endpoint Selection

See [my post on the mailing list](https://mailarchive.ietf.org/arch/msg/taps/u4imn1IKFBeSxwJRJK_HNwEoT98) for a more detailed description of this topic.