### PR TITLE
Various minor issues - closes #314, #315 #316 and #331

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -467,7 +467,7 @@ form \[\<Namespace>.\]\<PropertyName\>.
   for properties defined by an RFC which are not protocol specific.
 - Protocol Specific Properties must use the protocol acronym as
   Namespace, e.g., “tcp" for TCP specific Transport Properties.
-  For IETF protocols, property names under these namespaces should
+  For IETF protocols, property names under these namespaces SHOULD
   be defined in an RFC.
 - Vendor or implementation specific properties must use a
   a string identifying the vendor or implementation as Namespace.

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -92,7 +92,6 @@ author:
     email: tpauly@apple.com
 
 normative:
-  I-D.ietf-tsvwg-sctp-ndata:
   I-D.ietf-tsvwg-rtcweb-qos:
   I-D.ietf-taps-arch:
 
@@ -457,7 +456,8 @@ lower-case strings whereby words are separated by hyphens.
 These names serve two purposes:
 
 - Allow different components of a TAPS implementation to pass Transport
-  Properties, e.g., between a language frontend and a policy manager.
+  Properties, e.g., between a language frontend and a policy manager,
+  or as a representation of properties retrieved from a file or other storage.
 - Make code of different TAPS implementations look similar.
 
 Transport Property Names are hierarchically organized in the
@@ -720,7 +720,7 @@ This property specifies whether the application needs or prefers to use a transp
 protocol that preserves message boundaries. The recommended default
 is to Prefer Preservation of Message Boundaries.
 
-### Configure per-Message reliability {#prop-partially-reliable}
+### Configure Per-Message Reliability {#prop-partially-reliable}
 
 Name:
 : per-msg-reliability
@@ -730,7 +730,7 @@ its reliability requirements on a per-Message basis. This property applies to
 Connections and Connection Groups. The recommended default is to Ignore
 this option.
 
-### Preservation of data ordering {#prop-ordering}
+### Preservation of Data Ordering {#prop-ordering}
 
 Name:
 : preserve-order
@@ -740,7 +740,7 @@ protocol that can ensure that data is received by the application on the other
 end in the same order as it was sent. The recommended default is to Require
 Preservation of data ordering.
 
-### Use 0-RTT session establishment with an idempotent Message {#prop-0rtt}
+### Use 0-RTT Session Establishment with an Idempotent Message {#prop-0rtt}
 
 Name:
 : zero-rtt-msg
@@ -748,8 +748,11 @@ Name:
 This property specifies whether an application would like to supply a Message to
 the transport protocol before Connection establishment, which will then be
 reliably transferred to the other side before or during Connection
-establishment, potentially multiple times. See also {{msg-idempotent}}. The
-recommended default is to Prefer this option.
+establishment, potentially multiple times (i.e., multiple copies of the message data
+may be passed to the Remote Endpoint). See also {{msg-idempotent}}. The
+recommended default is to Ignore this option. Note that disabling this property
+has no effect for protocols that are not connection-oriented and do not protect
+against duplicated messages, e.g., UDP.
 
 ### Multistream Connections in Group {#prop-multistream}
 
@@ -758,26 +761,27 @@ Name:
 
 This property specifies that the application would prefer multiple Connections
 within a Connection Group to be provided by streams of a single underlying
-transport connection where possible. The recommended default is to Prefer have
+transport connection where possible. The recommended default is to Prefer 
 this option.
 
-### Control checksum coverage on sending {#prop-checksum-control-send}
+### Full Checksum Coverage on Sending {#prop-checksum-control-send}
 
 Name:
 : per-msg-checksum-len-send
 
-This property specifies whether the application considers it useful to enable,
-disable, or configure a checksum when sending a Message.  The recommended default
-is to Ignore this option.
+This property specifies whether the application desires protection against
+corruption for all data transmitted on this Connection. Disabling this property may enable
+to control checksum coverage later (see {{msg-checksum}}). The recommended default
+is to Require this option.
 
-### Control checksum coverage on receiving {#prop-checksum-control-receive}
+### Full Checksum Coverage on Receiving {#prop-checksum-control-receive}
 
 Name:
 : per-msg-checksum-len-recv
 
-This property specifies whether the application considers it useful configure whether to
-require a checksum or not when receiving.  The recommended default is to Ignore
-this option.
+This property specifies whether the application desires protection against
+corruption for all data received on this Connection. The recommended default
+is to Require this option.
 
 ### Congestion control {#prop-cc}
 
@@ -2076,7 +2080,7 @@ prefers protocols providing a specific transport feature that controlled by
 that protocol property. \[EDITOR'S NOTE: todo: add these cross-references up to {{selection-props}}]
 
 
-### Retransmission threshold before excessive retransmission notification {#conn-excss-retransmit}
+### Retransmission Threshold Before Excessive Retransmission Notification {#conn-excss-retransmit}
 
 Name:
 : retransmit-notify-threshold
@@ -2084,11 +2088,15 @@ Name:
 Type:
 : Integer
 
+Default:
+: -1
+
 This property specifies after how many retransmissions to inform the application
-about "Excessive Retransmissions".
+about "Excessive Retransmissions". The special value
+-1 means that this notification is disabled.
 
 
-### Required minimum coverage of the Corruption Protection for receiving {#conn-recv-checksum}
+### Required Minimum Corruption Protection Coverage for Receiving {#conn-recv-checksum}
 
 Name:
 : recv-checksum-len
@@ -2101,7 +2109,7 @@ Default:
 
 This property specifies the part of the received data that needs
 to be covered by a checksum. It is given in Bytes. A value of 0 means
-that no checksum is required, and a special value (e.g., -1) indicates
+that no checksum is required, and the special value -1 indicates
 full checksum coverage.
 
 ### Priority (Connection) {#conn-priority}
@@ -2112,13 +2120,16 @@ Name:
 Type:
 : Integer
 
+Default:
+: 100
+
 This Property is a non-negative integer representing the relative inverse
 priority of this Connection relative to other Connections in the same
 Connection Group. It has no effect on Connections not part of a Connection
 Group. As noted in {{groups}}, this property is not entangled when Connections
 are cloned.
 
-### Timeout for aborting Connection {#conn-timeout}
+### Timeout for Aborting Connection {#conn-timeout}
 
 Name:
 : conn-timeout
@@ -2126,12 +2137,16 @@ Name:
 Type:
 : Numeric
 
+Default:
+: -1
+
 This property specifies how long to wait before deciding that a Connection has
 failed when trying to reliably deliver data to the destination. Adjusting this Property
-will only take effect when the underlying stack supports reliability.
+will only take effect when the underlying stack supports reliability. The special value
+-1 means that this timeout is not scheduled to happen.
 
 
-### Connection group transmission scheduler {#conn-scheduler}
+### Connection Group Transmission Scheduler {#conn-scheduler}
 
 Name:
 : conn-scheduler
@@ -2139,11 +2154,14 @@ Name:
 Type:
 : Enumeration
 
+Default:
+: Weighted Fair Queueing (see Section 3.6 in {{?RFC8260}})
+
 This property specifies which scheduler should be used among Connections within
 a Connection Group, see {{groups}}. The set of schedulers can
-be taken from {{I-D.ietf-tsvwg-sctp-ndata}}.
+be taken from {{?RFC8260}}.
 
-### Maximum message size concurrent with Connection establishment {#size-idempotent}
+### Maximum Message Size Concurrent with Connection Establishment {#size-idempotent}
 
 Name:
 : zero-rtt-msg-max-len
@@ -2155,7 +2173,7 @@ This property represents the maximum Message size that can be sent
 before or during Connection establishment, see also {{msg-idempotent}}.
 It is given in Bytes.
 
-### Maximum Message size before fragmentation or segmentation {#conn-max-msg-notfrag}
+### Maximum Message Size Before Fragmentation or Segmentation {#conn-max-msg-notfrag}
 
 Name:
 : singular-transmission-msg-max-len
@@ -2167,7 +2185,7 @@ This property, if applicable, represents the maximum Message size that can be
 sent without incurring network-layer fragmentation or transport layer
 segmentation at the sender.
 
-### Maximum Message size on send {#conn-max-msg-send}
+### Maximum Message Size on Send {#conn-max-msg-send}
 
 Name:
 : send-msg-max-len
@@ -2177,7 +2195,7 @@ Type:
 
 This property represents the maximum Message size that can be sent.
 
-### Maximum Message size on receive {#conn-max-msg-recv}
+### Maximum Message Size on Receive {#conn-max-msg-recv}
 
 Name:
 : recv-msg-max-len
@@ -2206,7 +2224,7 @@ values are valid for the Capacity Profile:
   configuring transport protocol stacks. Transport system implementations that
   map the requested capacity profile onto per-connection DSCP signaling without
   multiplexing SHOULD assign the DSCP Default Forwarding {{?RFC2474}} PHB; when
-  the Connection is multiplexed, the guidelines in section 6 of {{?RFC7657}}
+  the Connection is multiplexed, the guidelines in Section 6 of {{?RFC7657}}
   apply.
 
   Scavenger:
@@ -2217,7 +2235,7 @@ values are valid for the Capacity Profile:
   map the requested capacity profile onto per-connection DSCP signaling without
   multiplexing SHOULD assign the DSCP Less than Best Effort
   {{?LE-PHB=I-D.ietf-tsvwg-le-phb}} PHB; when the Connection is multiplexed, the
-  guidelines in section 6 of {{?RFC7657}} apply.
+  guidelines in Section 6 of {{?RFC7657}} apply.
 
   Low Latency/Interactive:
   : The application is interactive, and prefers loss to
@@ -2229,7 +2247,7 @@ values are valid for the Capacity Profile:
   Transport system implementations that map the requested capacity profile onto
   per-connection DSCP signaling without multiplexing SHOULD assign the DSCP
   Expedited Forwarding {{?RFC3246}} PHB; when the Connection is multiplexed, the
-  guidelines in section 6 of {{?RFC7657}} apply.
+  guidelines in Section 6 of {{?RFC7657}} apply.
 
   Low Latency/Non-Interactive:
   : The application prefers loss to latency but is
@@ -2238,7 +2256,7 @@ values are valid for the Capacity Profile:
   system implementations that map the requested capacity profile onto
   per-connection DSCP signaling without multiplexing SHOULD assign a DSCP
   Assured Forwarding (AF21,AF22,AF23,AF24) {{?RFC2597}} PHB; when the Connection
-  is multiplexed, the guidelines in section 6 of {{?RFC7657}} apply.
+  is multiplexed, the guidelines in Section 6 of {{?RFC7657}} apply.
 
   Constant-Rate Streaming:
   : The application expects to send/receive data at a
@@ -2250,7 +2268,7 @@ values are valid for the Capacity Profile:
   system implementations that map the requested capacity profile onto
   per-connection DSCP signaling without multiplexing SHOULD assign a DSCP
   Assured Forwarding (AF31,AF32,AF33,AF34) {{?RFC2597}} PHB; when the Connection
-  is multiplexed, the guidelines in section 6 of {{?RFC7657}} apply.
+  is multiplexed, the guidelines in Section 6 of {{?RFC7657}} apply.
 
   High Throughput Data:
   : The application expects to send/receive data at the
@@ -2258,8 +2276,8 @@ values are valid for the Capacity Profile:
   period of time. Transport system implementations that map the requested
   capacity profile onto per-connection DSCP signaling without multiplexing
   SHOULD assign a DSCP Assured Forwarding (AF11,AF12,AF13,AF14) {{?RFC2597}} PHB
-  per section 4.8 of {{?RFC4594}}. When the Connection is multiplexed, the
-  guidelines in section 6 of {{?RFC7657}} apply.
+  per Section 4.8 of {{?RFC4594}}. When the Connection is multiplexed, the
+  guidelines in Section 6 of {{?RFC7657}} apply.
 
 The Capacity Profile for a selected protocol stack may be modified on a
 per-Message basis using the Transmission Profile Message Property; see
@@ -2272,12 +2290,16 @@ Name:
 : max-send-rate / max-recv-rate
 
 Type:
-: Integer (positive)
+: Integer (positive) / Integer (positive)
+
+Default:
+: -1 / -1 (unlimited, for both values)
 
 This property specifies an upper-bound rate that a transfer is not expected to
 exceed (even if flow control and congestion control allow higher rates), and/or a
 lower-bound rate below which the application does not deem
-a data transfer useful. It is given in bits per second.
+a data transfer useful. It is given in bits per second. The special value -1 indicates
+that no bound is specified.
 
 
 ### TCP-specific Property: User Timeout
@@ -2285,8 +2307,8 @@ a data transfer useful. It is given in bits per second.
 This property specifies, for the case TCP becomes the chosen transport protocol:
 
 Advertised User Timeout (name: tcp.user-timeout-value, type: Integer):
-: a time value to be advertised via the User Timeout Option (UTO) for the TCP at the remote endpoint
-to adapt its own "Timeout for aborting Connection" (see {{conn-timeout}}) value accordingly
+: a time value (default: the TCP default) to be advertised via the User Timeout Option (UTO) for the TCP at the remote endpoint
+to adapt its own "Timeout for aborting Connection" (see {{conn-timeout}}) value accordingly.
 
 User Timeout Enabled (name: tcp.user-timeout, type: Boolean):
 : a boolean (default false) to control whether the UTO option is enabled for a

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -2290,7 +2290,7 @@ Name:
 : max-send-rate / max-recv-rate
 
 Type:
-: Integer (positive) / Integer (positive)
+: Numeric / Numeric
 
 Default:
 : -1 / -1 (unlimited, for both values)


### PR DESCRIPTION
... and some nits (capitalization, ..)

#314: 0-rtt establishment: fixed default as requested by @gorryfair and incorporated text fix suggestion
#315: last missing update to hopefully close this issue: adjusted the wording of checksum related selection properties
#316: fixed some text details regarding how transport properties are to be specified, based on a converged discussion.
#331: wrote some defaults for parameters in section 9.1