### PR TITLE
Remove the message context returned by send

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1268,18 +1268,17 @@ Messages for streaming large data is also supported (see {{send-partial}}).
 Messages are sent on a Connection using the Send action:
 
 ~~~
-messageContext := Connection.Send(messageData, messageContext?, endOfMessage?)
+Connection.Send(messageData, messageContext?, endOfMessage?)
 ~~~
 
 where messageData is the data object to send.
 
 The optional messageContext parameter supports per-message properties and is
-described in {{message-props}}. If provided, the Message Context object returned is identical to the one that was passed. 
+described in {{message-props}}.
+It can be used to identify send events (see {{send-events}}) related to a specific message or to inspect meta-data related to the message sent (see {{msg-ctx}}).
 
 The optional endOfMessage parameter supports partial sending and is described in
 {{send-partial}}.
-
-The MessageContext returned by Send can be used to identify send events (see {{send-events}}) related to a specific message or to inspect meta-data related to the message sent. 
 
 ## Basic Sending {#send-basic}
 


### PR DESCRIPTION
This closes first half of Issue #336 as discussed today