### PR TITLE
add dates to references, and clean up spurious ones

### DIFF
--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -79,6 +79,7 @@ informative:
     POSIX:
       title: "IEEE Std. 1003.1-2008 Standard for Information Technology -- Portable Operating System Interface (POSIX).  Open group Technical Standard: Base Specifications, Issue 7"
       url: <http://www.opengroup.org/austin>
+      date: 2008
 
 --- abstract
 

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -96,18 +96,7 @@ informative:
           ins: F. Weinrank
         -
           ins: M. Tuexen
-    Trickle:
-      title: Trickle - Rate Limiting YouTube Video Streaming (ATC 2012)
-      url: https://www.usenix.org/system/files/conference/atc12/atc12-final236.pdf
-      authors:
-        -
-          ins: M. Ghobadi
-        -
-          ins: Y. Cheng
-        -
-          ins: A. Jain
-        -
-          ins: M. Mathis
+      date: 2017
 
 
 --- abstract


### PR DESCRIPTION
This is necessary to allow CircleCI builds, which have changed to use XMLv3 in the workflow, to continue: XMLv3 requires a <date year> attribute in all refs, where v2 did not.