### PR TITLE
Add a reference to DPLPMTUD for Message Size before fragmentation

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -2203,7 +2203,8 @@ Type:
 
 This property, if applicable, represents the maximum Message size that can be
 sent without incurring network-layer fragmentation or transport layer
-segmentation at the sender.
+segmentation at the sender. This property models the Maximum Packet Size (MPS)
+as described in Datagram PLPMTUD {{?I-D.ietf.tsvwg.datagram-plpmtud}}.
 
 ### Maximum Message Size on Send {#conn-max-msg-send}
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -2204,7 +2204,7 @@ Type:
 This property, if applicable, represents the maximum Message size that can be
 sent without incurring network-layer fragmentation or transport layer
 segmentation at the sender. This property exposes the Maximum Packet Size (MPS)
-as described in Datagram PLPMTUD {{?I-D.ietf.tsvwg.datagram-plpmtud}}.
+as described in Datagram PLPMTUD {{?I-D.ietf-tsvwg-datagram-plpmtud}}.
 
 ### Maximum Message Size on Send {#conn-max-msg-send}
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -2203,7 +2203,7 @@ Type:
 
 This property, if applicable, represents the maximum Message size that can be
 sent without incurring network-layer fragmentation or transport layer
-segmentation at the sender. This property models the Maximum Packet Size (MPS)
+segmentation at the sender. This property exposes the Maximum Packet Size (MPS)
 as described in Datagram PLPMTUD {{?I-D.ietf.tsvwg.datagram-plpmtud}}.
 
 ### Maximum Message Size on Send {#conn-max-msg-send}


### PR DESCRIPTION
Add a reference to MPS in DPLPMTUD for the Message Size Before Fragmentation property.