### PR TITLE
Protocol Specific Properties are not well defined

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -463,8 +463,8 @@ earlier stages and querying them in later stages:
 Note that configuring Connection Properties and Message Properties on
 Preconnections is preferred over setting them later. Early specification of
 Connection Properties allows their use as additional input to the selection
-process. Protocol Specific Properties, that enable configuration of Specialized
-Features of a specific protocol, see Section 3.2 of {{I-D.ietf-taps-arch}}, are not
+process. Protocol Specific Properties, which enable configuration of specialized
+features of a specific protocol, see Section 3.2 of {{I-D.ietf-taps-arch}}, are not
 used as an input to the selection process but only support configuration if
 the respective prototocol has been selected.
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -463,8 +463,10 @@ earlier stages and querying them in later stages:
 Note that Configuring Connection Properties and Message Properties on
 Preconnections is preferred over setting them later. Early specification of
 Connection Properties allows their use as additional input to the selection
-process. Protocol Specific Properties, see {{property-names}}, should not be
-used as an input to the selection process.
+process. Protocol Specific Properties, that enable configuration of Specialized
+Features of a specific protocol, see sec 3.2 of {{I-D.ietf-taps-arch}}, are not
+used as an input to the selection process but only support configuration if
+the respective prototocol has been selected.
 
 
 ### Transport Property Names {#property-names}

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -460,7 +460,7 @@ earlier stages and querying them in later stages:
 - Message Properties can be set on Preconnections and Connections
 - The effect of Selection Properties can be queried on Connections and Messages
 
-Note that Configuring Connection Properties and Message Properties on
+Note that configuring Connection Properties and Message Properties on
 Preconnections is preferred over setting them later. Early specification of
 Connection Properties allows their use as additional input to the selection
 process. Protocol Specific Properties, that enable configuration of Specialized

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -464,7 +464,7 @@ Note that configuring Connection Properties and Message Properties on
 Preconnections is preferred over setting them later. Early specification of
 Connection Properties allows their use as additional input to the selection
 process. Protocol Specific Properties, that enable configuration of Specialized
-Features of a specific protocol, see sec 3.2 of {{I-D.ietf-taps-arch}}, are not
+Features of a specific protocol, see Section 3.2 of {{I-D.ietf-taps-arch}}, are not
 used as an input to the selection process but only support configuration if
 the respective prototocol has been selected.
 


### PR DESCRIPTION
The term Protocol Specific Properties is not well introduced. In the Arch doc we have a section about "Specialized Features" and I not added a reference and rephrased the sentence respectively. Do we need to say more than that?