### PR TITLE
"must provide sensible defaults"

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -742,11 +742,12 @@ after establishment yields the value Required for properties of the selected
 protocol and path, Avoid for properties avoided during selection, and Ignore for
 all other properties.
 
-An implementation of this interface must provide sensible defaults for Selection
-Properties. The defaults given for each property below represent a
-configuration that can be implemented over TCP. An alternate set of default
-Protocol Selection Properties would represent a configuration that can be
-implemented over UDP.
+An implementation of this interface SHOULD use the defaults given 
+for each property below. These values represent a configuration that 
+can be implemented over TCP. If TCP is not supported or another default
+protocol is preferred, the implementation MUST specify an alternate set of
+default Protocol Selection Properties that represents a configuration that 
+can be implemented over the preferred protocol, such as UDP.
 
 
 ### Reliable Data Transfer (Connection) {#prop-reliable}

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -745,9 +745,9 @@ all other properties.
 An implementation of this interface must provide sensible defaults for Selection
 Properties. The recommended default values for each property below represent a
 configuration that can be implemented over TCP. If these default values are used
-and TCP is not supported by a TAPS implementation, then an application using the
+and TCP is not supported by a Transport Services implementation, then an application using the
 default set of Properties might not succeed in establishing a connection. Using
-the same default values for independent TAPS implementations can be beneficical
+the same default values for independent Transport Services implementations can be beneficical
 when application are ported between different implementation, even if the
 default could lead to a connection failure, as, for example, applications need
 explicitly be designed to also support a connectionless mode. In this case the

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -742,12 +742,19 @@ after establishment yields the value Required for properties of the selected
 protocol and path, Avoid for properties avoided during selection, and Ignore for
 all other properties.
 
-An implementation of this interface SHOULD use the defaults given 
-for each property below. These values represent a configuration that 
-can be implemented over TCP. If TCP is not supported or another default
-protocol is preferred, the implementation MUST specify an alternate set of
-default Protocol Selection Properties that represents a configuration that 
-can be implemented over the preferred protocol, such as UDP.
+An implementation of this interface must provide sensible defaults for Selection
+Properties. The recommended default values for each property below represent a
+configuration that can be implemented over TCP. If these default values are used
+and TCP is not supported by a TAPS implementation, then an application using the
+default set of Properties might not succeed in establishing a connection. Using
+the same default values for independent TAPS implementations can be beneficical
+when application are ported between the different implementation, even if the
+default could let to a connection failure, as, for example, applications need
+explicitly be designed to also support a connectionless mode. In this case the
+application can regonized the failure and explicitly specify a different set of
+Protocol Selection Properties that result in a usable protocol. If other default
+values than recommended below are used, it is recommended to document that well
+for application use.
 
 
 ### Reliable Data Transfer (Connection) {#prop-reliable}

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -748,13 +748,12 @@ configuration that can be implemented over TCP. If these default values are used
 and TCP is not supported by a TAPS implementation, then an application using the
 default set of Properties might not succeed in establishing a connection. Using
 the same default values for independent TAPS implementations can be beneficical
-when application are ported between the different implementation, even if the
-default could let to a connection failure, as, for example, applications need
+when application are ported between different implementation, even if the
+default could lead to a connection failure, as, for example, applications need
 explicitly be designed to also support a connectionless mode. In this case the
 application can regonized the failure and explicitly specify a different set of
 Protocol Selection Properties that result in a usable protocol. If other default
-values than recommended below are used, it is recommended to document that well
-for application use.
+values than recommended below are used, it is recommended to document that well.
 
 
 ### Reliable Data Transfer (Connection) {#prop-reliable}

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -748,12 +748,12 @@ configuration that can be implemented over TCP. If these default values are used
 and TCP is not supported by a Transport Services implementation, then an application using the
 default set of Properties might not succeed in establishing a connection. Using
 the same default values for independent Transport Services implementations can be beneficical
-when application are ported between different implementation, even if the
-default could lead to a connection failure, as, for example, applications need
-explicitly be designed to also support a connectionless mode. In this case the
-application can regonized the failure and explicitly specify a different set of
-Protocol Selection Properties that result in a usable protocol. If other default
-values than recommended below are used, it is recommended to document that well.
+when application are ported between different implementations, even if this
+default could lead to a connection failure, as, for example, an application needs to be
+explicitly designed to support a connectionless mode. In this case the
+application can regonize the failure and explicitly specify a different set of
+Protocol Selection Properties that result in a usable protocol. If default
+values other than those recommended below are used, it is recommended to clearly document the differences.
 
 
 ### Reliable Data Transfer (Connection) {#prop-reliable}


### PR DESCRIPTION
I was about to change this must to MUST, however, MUST and "sensible" doesn't work well together, so I proposed this recommendation instead.