### PR TITLE
Minor fixes with messageContexts, fixes #408

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1290,7 +1290,7 @@ resulting Connection is contained within the RendezvousDone<> Event, and is
 ready to use as soon as it is passed to the application via the Event.
 
 ~~~
-Preconnection -> RendezvousError<messageContext, reason?>
+Preconnection -> RendezvousError<reason?>
 ~~~
 
 An RendezvousError occurs either when the Properties and Security Parameters of the Preconnection cannot be fulfilled
@@ -1393,9 +1393,9 @@ Connection.Send(messageData, messageContext?, endOfMessage?)
 
 where messageData is the data object to send.
 
-The optional messageContext parameter supports per-message properties and is
+The optional messageContext parameter allows adding Message Properties as
 described in {{message-props}}.
-It can be used to identify send events (see {{send-events}}) related to a specific message or to inspect meta-data related to the message sent (see {{msg-ctx}}).
+Moreover, the messageContext can be used to identify Send Events related to a specific Message (see {{send-events}}) or to inspect meta-data related to the Message sent (see {{msg-ctx}}).
 
 The optional endOfMessage parameter supports partial sending and is described in
 {{send-partial}}.
@@ -1462,8 +1462,8 @@ underlying Protocol Stack and is no longer the responsibility of
 this interface. The exact disposition of the Message (i.e.,
 whether it has actually been transmitted, moved into a buffer on the network
 interface, moved into a kernel buffer, and so on) when the Sent Event occurs
-is implementation-specific. The Sent Event contains an implementation-specific
-reference to the Message to which it applies.
+is implementation-specific. The Sent Event contains a reference to the Message
+to which it applies.
 
 Sent Events allow an application to obtain an understanding of the amount
 of buffering it creates. That is, if an application calls the Send Action multiple
@@ -1480,8 +1480,8 @@ Connection -> Expired<messageContext>
 The Expired Event occurs when a previous Send Action expired before completion;
 i.e. when the Message was not sent before its Lifetime (see {{msg-lifetime}})
 expired. This is separate from SendError, as it is an expected behavior for
-partially reliable transports. The Expired Event contains an
-implementation-specific reference to the Message to which it applies.
+partially reliable transports. The Expired Event contains a reference to the
+Message to which it applies.
 
 ### SendError {#send-error}
 
@@ -1493,8 +1493,7 @@ A SendError occurs when a Message could not be sent due to an error condition:
 an attempt to send a Message which is too large for the system and
 Protocol Stack to handle, some failure of the underlying Protocol Stack, or a
 set of Message Properties not consistent with the Connection's transport
-properties. The SendError contains an implementation-specific reference to the
-Message to which it applies.
+properties. The SendError contains a reference to the Message to which it applies.
 
 ## Message Contexts {#msg-ctx}
 
@@ -1508,7 +1507,7 @@ MessageContext.add(scope?, parameter, value)
 PropertyValue := MessageContext.get(scope?, property)
 ~~~
 
-To get or set Message Properties, the optional scope parameter is left empty, for framing meta-data, the framer is passed.
+To get or set Message Properties, the optional scope parameter is left empty. To get or set meta-data for a Framer, the application has to pass a reference to this Framer as the scope parameter.
 
 For MessageContexts returned by send events (see {{send-events}}) and receive events (see {{receive-events}}), the application can query information about the local and remote endpoint:
 


### PR DESCRIPTION
Tentatively answering my own questions in #408:

> The RendezvousError (Section 6.3) includes a messageContext (which is even required), but neither the InitiateError nor the ListenError include one. Why? Should this messageContext at least be optional?

Removed the messageContext here because the RendezvousError does not necessarily relate to a specific sent Message. If it does, the "reason" parameter can point to that message and/or a messageContext.

> In Section 7.3, it says "The Sent Event contains an implementation-specific reference to the Message to which it applies." - Is this in addition to the messageContext? If yes, why do we need both?

The beginning of Section 7 actually already said that this IS the messageContext. I removed the word "implementation-specific" because to me this word made it sound like this reference can't be the messageContext.

> In Section 9, it says "To get or set Message Properties, the optional scope parameter is left empty, for framing meta-data, the framer is passed." - I think this sentence is a bit hard to parse and it wasn't immediately obvious to me what kind of framing meta-data this refers to. Perhaps this refers to Section 10.2, so I think it's worth adding a reference to that section here. Also, I suggest turning this into two sentences, with the sentence on framing meta-data specifying that this is per-Message metadata to be used by the framer.

Split into two sentences and changed the second sentence to active voice.

Also, I slightly reworded the beginning of Section 7, which is now a bit clearer in my opinion.