### PR TITLE
Add justification and normative language, fixes #429

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -713,14 +713,21 @@ In addition, the pseudo-level ``Default`` can be used to reset the property to t
 level used by the implementation. This level will never show up when queuing the value of
 a preference - the effective preference must be returned instead.
 
-Internally, the transport system will first exclude all protocols and paths that
-match a Prohibit, then exclude all protocols and paths that do not match a
-Require, then sort candidates according to Preferred properties, and then use
-Avoided properties as a tiebreaker. Selection Properties that select paths take
-preference over those that select protocols. For example, if an application
-indicates a preference for a specific path by specifying an interface, but also a
-preference for a protocol not available on this path, the transport system will
-try the path first, ignoring the protocol preference.
+The implementation MUST ensure a consistent outcome given the same Selection
+Properties. Internally, it MUST exclude all protocols and paths that match a
+Prohibit and exclude all protocols and paths that do not match a Require. It
+MUST then sort candidates according to Preferred properties, and then use
+Avoided properties as a tiebreaker. 
+
+Note that the protocols and paths which are available on a specific system may
+vary, such that application preferences may conflict with each other. For
+example, if an application indicates a preference for a specific path by
+specifying an interface, but also a preference for a protocol, a situation
+might occur in which the preferred protocol is not available on the preferred
+path. In such cases, implementations MUST ensure a deterministic outcome by
+prioritizing Selection Properties that select paths over those that select
+protocols. Therefore, the transport system MUST try the path first, ignoring
+the protocol preference if the protocol does not work on the path.
 
 Selection and Connection Properties, as well as defaults for Message
 Properties, can be added to a Preconnection to configure the selection process


### PR DESCRIPTION
Took a stab at normative language for the rules to process Selection Properties, as discussed in #429.

As far as I remember, we always said that outcomes have to be deterministic/consistent, so I made everything that matters a MUST.
I guess our example illustrates that even given the same Selection Properties, the outcome might change depending on the situation, e.g., your path might still be Wifi but it might or might not support your preferred protocol.

So, does this really have to be all MUST, or is there a SHOULD in there? Discuss. :)

Also, if anyone can name a good reason why the outcome has to be deterministic, please suggest text - maybe something like "avoid surprises for the application", but this didn't really sound right, so I left it out for now.