### PR TITLE
Refactor Local Address Preference, fixes #436

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -946,16 +946,17 @@ Name:
 : local-address-preference
 
 Type:
-: Enumeration
+: Set (Preference, Enumeration)
 
-This property specifies whether Listeners and Connections should prefer the use of temporary addresses when possible.
-This is generally used to prevent linking connections over time when a stable address is not needed. Possible values are:
+This property allows the application to control the use of stable or temporary local addresses.
+Temporary addresses are generally used to prevent linking connections over time when a stable address is not needed.
+Note that expressing preferences for both stable and temporary addresses can be redundant and/or produce a conflict. Possible values are:
 
 Stable:
-: Prefer the use of stable (sometimes called "permanent") local addresses
+: Use stable (sometimes called "permanent") local addresses
 
 Temporary:
-: Prefer the use of temporary (sometimes called "privacy") addresses {{!RFC4941}}
+: Use temporary (sometimes called "privacy") addresses {{!RFC4941}}
 
 The default is to prefer the use of stable local addresses for Listeners and
 Rendezvous Connections, and to prefer the use of temporary addresses for other

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -940,27 +940,19 @@ requiring specific PvD instances or interface instances, and should be preferred
 over these options.
 
 
-### Local Address Preference
+### Use Temporary Local Addresses
 
 Name:
-: local-address-preference
+: use-temporary-local-address
 
 Type:
-: (Preference, Enumeration)
+: Preference
 
-This property allows the application to control the use of stable or temporary local addresses.
-Temporary addresses are generally used to prevent linking connections over time when a stable address is not needed.
-Possible values are:
+Default:
+: Prefer for Active Open (Initiate), Avoid for Passive Open (Listen) and Rendezvous Connections.
 
-Stable:
-: Use stable (sometimes called "permanent") local addresses
-
-Temporary:
-: Use temporary (sometimes called "privacy") addresses {{!RFC4941}}
-
-The default is to Prefer the use of stable local addresses for Listeners and
-Rendezvous Connections, and to Prefer the use of temporary addresses for other
-Connections.
+This property allows the application to express a preference for the use of temporary local addresses, sometimes called "privacy" addresses {{!RFC4941}}.
+Temporary addresses are generally used to prevent linking connections over time when a stable address, sometimes called "permanent" address, is not needed.
 
 
 ### Parallel Use of Multiple Paths {#parallel-multipath}

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -946,11 +946,11 @@ Name:
 : local-address-preference
 
 Type:
-: Set (Preference, Enumeration)
+: (Preference, Enumeration)
 
 This property allows the application to control the use of stable or temporary local addresses.
 Temporary addresses are generally used to prevent linking connections over time when a stable address is not needed.
-Note that expressing preferences for both stable and temporary addresses can be redundant and/or produce a conflict. Possible values are:
+Possible values are:
 
 Stable:
 : Use stable (sometimes called "permanent") local addresses

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1016,7 +1016,7 @@ particular instance. While this does restrict path selection, it is broader than
 requiring specific PvD instances or interface instances, and should be preferred
 over these options.
 
-### Use Temporary Local Addresses
+### Use Temporary Local Address
 
 Name:
 : use-temporary-local-address

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -958,8 +958,8 @@ Stable:
 Temporary:
 : Use temporary (sometimes called "privacy") addresses {{!RFC4941}}
 
-The default is to prefer the use of stable local addresses for Listeners and
-Rendezvous Connections, and to prefer the use of temporary addresses for other
+The default is to Prefer the use of stable local addresses for Listeners and
+Rendezvous Connections, and to Prefer the use of temporary addresses for other
 Connections.
 
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1031,6 +1031,9 @@ This property allows the application to express a preference for the use of
 temporary local addresses, sometimes called "privacy" addresses {{!RFC4941}}.
 Temporary addresses are generally used to prevent linking connections over time
 when a stable address, sometimes called "permanent" address, is not needed.
+Note that if an application Requires the use of temporary addresses, the
+resulting Connection cannot use IPv4, as temporary addresses do not exist in
+IPv4.
 
 
 ### Parallel Use of Multiple Paths {#parallel-multipath}


### PR DESCRIPTION
Following the suggestion in #436, made Local Address Preference a Set(Preference, Enumeration), so an application can now also Require or Prohibit stable addresses.
Added a sentence warning that, e.g., preferring stable AND temporary addresses does not make sense - but there are less obvious ways to produce a conflicting set of Selection Properties, too, and we know how to deal with them.