### PR TITLE
Move algorithm text to Implementation draft, make Interface draft more flexible

### DIFF
--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -174,8 +174,8 @@ Aggregate [Endpoint: www.example.com:80] [Interface: Any]   [Protocol: TCP]
 Any one of these sub-entries on the aggregate connection attempt would satisfy the original application intent. The concern of this section is the algorithm defining which of these options to try, when, and in what order.
 
 During Candidate Gathering, an implementation first excludes all protocols and
-paths that match a Prohibit and all protocols and paths that do not match a
-Require. Then, the implementation will sort branches according to Preferred
+paths that match a Prohibit or do not match all Require properties.
+Then, the implementation will sort branches according to Preferred
 properties, Avoided properties, and possibly other criteria.
 
 

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -173,6 +173,12 @@ Aggregate [Endpoint: www.example.com:80] [Interface: Any]   [Protocol: TCP]
 
 Any one of these sub-entries on the aggregate connection attempt would satisfy the original application intent. The concern of this section is the algorithm defining which of these options to try, when, and in what order.
 
+During Candidate Gathering, an implementation first excludes all protocols and
+paths that match a Prohibit and all protocols and paths that do not match a
+Require. Then, the implementation will sort branches according to Preferred
+properties, Avoided properties, and possibly other criteria.
+
+
 ## Candidate Gathering {#gathering}
 
 The step of gathering candidates involves identifying which paths, protocols, and endpoints may be used for a given Connection. This list is determined by the requirements, prohibitions, and preferences of the application as specified in the Selection Properties.
@@ -372,7 +378,9 @@ An implementation may use the Capacity Profile to prefer paths optimized for the
 
 Implementations should process properties in the following order: Prohibit, Require, Prefer, Avoid.
 If Selection Properties contain any prohibited properties, the implementation should first purge branches containing nodes with these properties. For required properties, it should only keep branches that satisfy these requirements. Finally, it should order branches according to preferred properties, and finally use avoided properties as a tiebreaker.
+When ordering branches, an implementation may give more weight to properties that the application has explicitly set than to properties that are default.
 
+As the available protocols and paths on a specific system and in a specific context may vary, the result of sorting and the outcome of racing may vary even given the same Selection and Connection Properties. However, an implementation may aim to provide a consistent outcome to applications, e.g., by preferring protocols and paths that existing Connections with similar Properties are already using.
 
 
 ## Candidate Racing

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -380,7 +380,7 @@ Implementations should process properties in the following order: Prohibit, Requ
 If Selection Properties contain any prohibited properties, the implementation should first purge branches containing nodes with these properties. For required properties, it should only keep branches that satisfy these requirements. Finally, it should order branches according to preferred properties, and finally use avoided properties as a tiebreaker.
 When ordering branches, an implementation may give more weight to properties that the application has explicitly set than to properties that are default.
 
-As the available protocols and paths on a specific system and in a specific context may vary, the result of sorting and the outcome of racing may vary even given the same Selection and Connection Properties. However, an implementation may aim to provide a consistent outcome to applications, e.g., by preferring protocols and paths that existing Connections with similar Properties are already using.
+As the available protocols and paths on a specific system and in a specific context may vary, the result of sorting and the outcome of racing may vary even given the same Selection and Connection Properties. However, an implementation ought to aim to provide a consistent outcome to applications, e.g., by preferring protocols and paths that existing Connections with similar Properties are already using.
 
 
 ## Candidate Racing

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -731,21 +731,20 @@ In addition, the pseudo-level ``Default`` can be used to reset the property to t
 level used by the implementation. This level will never show up when queuing the value of
 a preference - the effective preference must be returned instead.
 
-The implementation MUST ensure a consistent outcome given the same Selection
-Properties. Internally, it MUST exclude all protocols and paths that match a
-Prohibit and exclude all protocols and paths that do not match a Require. It
-MUST then sort candidates according to Preferred properties, and then use
-Avoided properties as a tiebreaker. 
+The implementation MUST ensure an outcome that is consistent with application
+requirements as expressed using Require and Prohibit. While preferences
+expressed using Prefer and Avoid influence protocol and path selection as well,
+outcomes may vary given the same Selection Properties, as the available
+protocols and paths may vary across systems and contexts.
 
-Note that the protocols and paths which are available on a specific system may
-vary, such that application preferences may conflict with each other. For
+Note that application preferences may conflict with each other. For
 example, if an application indicates a preference for a specific path by
 specifying an interface, but also a preference for a protocol, a situation
 might occur in which the preferred protocol is not available on the preferred
-path. In such cases, implementations MUST ensure a deterministic outcome by
-prioritizing Selection Properties that select paths over those that select
-protocols. Therefore, the transport system MUST try the path first, ignoring
-the protocol preference if the protocol does not work on the path.
+path. In such cases, implementations SHOULD prioritize Selection Properties
+that select paths over those that select protocols. Therefore, the transport
+system SHOULD try the path first, ignoring the protocol preference if the
+protocol does not work on the path.
 
 Selection and Connection Properties, as well as defaults for Message
 Properties, can be added to a Preconnection to configure the selection process

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -735,7 +735,9 @@ The implementation MUST ensure an outcome that is consistent with application
 requirements as expressed using Require and Prohibit. While preferences
 expressed using Prefer and Avoid influence protocol and path selection as well,
 outcomes may vary given the same Selection Properties, as the available
-protocols and paths may vary across systems and contexts.
+protocols and paths may vary across systems and contexts. However,
+implementations are RECOMMENDED to aim to provide a consistent outcome
+to an application, given the same Selection Properties.
 
 Note that application preferences may conflict with each other. For
 example, if an application indicates a preference for a specific path by
@@ -743,7 +745,7 @@ specifying an interface, but also a preference for a protocol, a situation
 might occur in which the preferred protocol is not available on the preferred
 path. In such cases, implementations SHOULD prioritize Selection Properties
 that select paths over those that select protocols. Therefore, the transport
-system SHOULD try the path first, ignoring the protocol preference if the
+system SHOULD race the path first, ignoring the protocol preference if the
 protocol does not work on the path.
 
 Selection and Connection Properties, as well as defaults for Message


### PR DESCRIPTION
In the [February 2020 interim](http://etherpad.tools.ietf.org:9000/p/notes-ietf-interim-2020-feb), people found the normative language in #496 too restrictive and agreed with the original suggestion in #429.
Therefore, this PR moves the selection algorithm text to the implementation draft and removes some normative language in the interface draft.
We still want to provide consistency to applications when possible, so there's a sentence in the implementation draft on this now as well.