### PR TITLE
No reference in abstract

### DIFF
--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -101,7 +101,9 @@ informative:
 
 --- abstract
 
-The Transport Services architecture {{I-D.ietf-taps-arch}} defines a system that allows applications to use transport networking protocols flexibly. This document serves as a guide to implementation on how to build such a system.
+The Transport Services (TAPS) system enables applications to use transport protocols flexibly for network communication
+and defines an protocol-independent TAPS Application Programming Interface (API) that is based on an asynchronous, 
+event-driven interaction pattern. This document serves as a guide to implementation on how to build such a system.
 
 --- middle
 

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -102,7 +102,7 @@ informative:
 --- abstract
 
 The Transport Services (TAPS) system enables applications to use transport protocols flexibly for network communication
-and defines an protocol-independent TAPS Application Programming Interface (API) that is based on an asynchronous, 
+and defines a protocol-independent TAPS Application Programming Interface (API) that is based on an asynchronous, 
 event-driven interaction pattern. This document serves as a guide to implementation on how to build such a system.
 
 --- middle


### PR DESCRIPTION
You cannot have references in the abstract. Initially I only wanted to remove that reference but then I also took the opportunity to rewrite the abstract a bit to not only talk about the architecture but an TAPS _system_ and the interface that this guide helps with its implementation.