### PR TITLE
API: state "Ephemeral port used when no Local Endpoint specified"

### DIFF
--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -465,7 +465,7 @@ However, if a peer is not reachable over the network using the unconnected proto
 
 ## Implementing listeners {#listen}
 
-When an implementation is asked to Listen, it registers with the system to wait for incoming traffic to the Local Endpoint. If no Local Endpoint is specified, the implementation should either use an ephemeral port or generate an error.
+When an implementation is asked to Listen, it registers with the system to wait for incoming traffic to the Local Endpoint. If no Local Endpoint is specified, the implementation should use an ephemeral port.
 
 If the Selection Properties do not require a single network interface or path, but allow the use of multiple paths, the Listener object should register for incoming traffic on all of the network interfaces or paths that conform to the Properties. The set of available paths can change over time, so the implementation should monitor network path changes and register and de-register the Listener across all usable paths. When using multiple paths, the Listener is generally expected to use the same port for listening on each.
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -589,7 +589,9 @@ of the potential Connection (see {{endpointspec}}), the Selection Properties
 
 The Local Endpoint MUST be specified if the Preconnection is used to Listen()
 for incoming Connections, but is OPTIONAL if it is used to Initiate()
-connections. The Remote Endpoint MUST be specified if the Preconnection is used
+connections. If no Local Endpoint is specified, the Transport System will
+assign an ephemeral local port to the Connection.
+The Remote Endpoint MUST be specified if the Preconnection is used
 to Initiate() Connections, but is OPTIONAL if it is used to Listen() for
 incoming Connections.
 The Local Endpoint and the Remote Endpoint MUST both be specified if a


### PR DESCRIPTION
Closes #539.