### PR TITLE
Define a new type to use when selection properties are queried

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -777,10 +777,16 @@ from an antecedent via cloning; see {{groups}} for more.
 {{connection-props}} provides a list of Connection Properties, while Selection
 Properties are listed in the subsections below. Note that many properties are
 only considered during establishment, and can not be changed after a Connection
-is established; however, they can be queried. Querying a Selection Property
-after establishment yields the value `Require` for properties of the selected
-protocol and path, Avoid for properties avoided during selection, and Ignore for
-all other properties.
+is established; however, they can be queried. The return type of a queried
+Selection Property is Boolean, where `true` means that the Selection Property
+has been applied and `false` means that the Selection Property has not
+been applied. Note that `true` does not mean that a request has been honored.
+For example, if `Congestion control` was
+requested with preference level `Prefer`, but congestion control could not
+be supported, querying the `congestionControl` property yields the
+value `false`. If preference level `Avoid` was used for `Congestion control`,
+and, as requested, the Connection is not congestion controlled, querying
+the `congestionControl` property also yields the value `false`.
 
 An implementation of this interface must provide sensible defaults for Selection
 Properties. The defaults given for each property below represent a

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -530,7 +530,9 @@ Transport Properties can have one of a set of data types:
   entire set of possible values for each property.
 - Preference: can take one of five values (Prohibit, Avoid, Ignore, Prefer,
   Require) for the level of preference of a given property during protocol
-  selection; see {{selection-props}}.
+  selection; see {{selection-props}}. When querying, a Preference is of
+  type Boolean, with `true` indicating that the Selection Property
+  has been applied.
 
 For types Integer and Numeric, special values can be defined
 per property; it is up to implementations how these special values are


### PR DESCRIPTION
Closes #528.
I chose boolean, because, when querying, it only matters whether a Selection Property was chosen or not (I believe).