### PR TITLE
Remove the "lower-case" requirement for transport property names

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -489,7 +489,7 @@ the respective protocol has been selected.
 ### Transport Property Names {#property-names}
 
 Transport Properties are referred to by property names. These names are
-lower-case alphanumeric strings in which words may be separated by hyphens.
+alphanumeric strings in which words may be separated by hyphens.
 These names serve two purposes:
 
 - Allowing different components of a TAPS implementation to pass Transport


### PR DESCRIPTION
This doesn't change the idea of translating keywords from the IANA protocol numbers registry to lower-case; it just removes the requirement for all Transport Property Names to be lower-case.

Why? Right now, they're camlCase, and I guess that reads better than changing them all into hardtoreadstrings or using-hyphens-everywhere ...
