### PR TITLE
Ignore preservation of message boundaries for selection by default.

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -938,7 +938,7 @@ Type:
 : Preference
 
 Default:
-: Prefer
+: Ignore
 
 This property specifies whether the application needs or prefers to use a transport
 protocol that preserves message boundaries.


### PR DESCRIPTION
Fixes #806