### PR TITLE
Fix two minor typos in architecture document

### DIFF
--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -193,7 +193,7 @@ The Socket API provides a message interface for datagram protocols like UDP, but
 The Transport Services API represents data as messages, so that it more closely matches the way applications use the network. Providing a message-based abstraction provides many benefits, such as:
 
 * the ability to associate deadlines with messages, for applications that care about timing;
-* the ability control reliability, which messages to retransmit when there is packet loss, and how best to make use of the data that arrived;
+* the ability to control reliability, which messages to retransmit when there is packet loss, and how best to make use of the data that arrived;
 * the ability to automatically assign messages and connections to underlying transport connections to utilize multi-streaming and pooled connections.
 
 Allowing applications to interact with messages is backwards-compatible with existing protocols and APIs because it does not change the wire format of any protocol. Instead, it gives the protocol stack additional information to allow it to make better use of modern transport services, while simplifying the application's role in parsing data. For protocols which natively use a streaming abstraction, framers ({{datatransfer}}) bridge the gap between the two abstractions.
@@ -270,7 +270,7 @@ This section and the remainder of this document describe the architecture non-no
 The architecture divides the concepts for Transport Services system into two categories:
 
 1. API concepts, which are intended to be exposed to applications; and
-2. System-implementation concepts, which are intended to be internally used by aTransport Services implementation.
+2. System-implementation concepts, which are intended to be internally used by a Transport Services implementation.
 
 The following diagram summarizes the top-level concepts in the architecture and how they relate to one another.
 


### PR DESCRIPTION
This pull requests fixes two minor typos in draft-ietf-taps-arch.md that I noticed during detailed reading of the draft.