### PR TITLE
Reading Selection Properties, etc.  Resolves #1012

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1001,17 +1001,17 @@ via a Preconnection, by configuration after establishment, or by inheriting them
 from an antecedent via cloning; see {{groups}} for more.
 
 {{connection-props}} provides a list of Connection Properties, while Selection
-Properties are listed in the subsections below. Many properties are
+Properties are listed in the subsections below. Sepection Properties are
 only considered during establishment, and can not be changed after a Connection
-is established; however, they can still be queried. The return type of a queried
+is established; however, they can still be read. The return type of a read
 Selection Property is Boolean, where `true` means that the Selection Property
 has been applied and `false` means that the Selection Property has not
 been applied. Note that `true` does not mean that a request has been honored.
 For example, if `Congestion control` was
 requested with preference level `Prefer`, but congestion control could not
-be supported, querying the `congestionControl` property yields the
+be supported, reading the `congestionControl` property yields the
 value `false`. If the preference level `Avoid` was used for `Congestion control`,
-and, as requested, the Connection is not congestion controlled, querying
+and, as requested, the Connection is not congestion controlled, reading
 the `congestionControl` property also yields the value `false`.
 
 An implementation of the Transport Services API must provide sensible defaults for Selection

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1004,7 +1004,7 @@ from an antecedent via cloning; see {{groups}} for more.
 Properties are listed in the subsections below. Selection Properties are
 only considered during establishment, and can not be changed after a Connection
 is established; however, they can still be read. Upon reading, the Preference type
-of a Selection Property changes into Boolean, where where `true` means that the
+of a Selection Property changes into Boolean, where `true` means that the
 Preference was honored and `false` means that it has not been honored (implementations
 of Transport Services systems may alternatively use the two Preference values `Require`
 and `Prohibit` to represent `true` and `false`, respectively).

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1001,7 +1001,7 @@ via a Preconnection, by configuration after establishment, or by inheriting them
 from an antecedent via cloning; see {{groups}} for more.
 
 {{connection-props}} provides a list of Connection Properties, while Selection
-Properties are listed in the subsections below. Sepection Properties are
+Properties are listed in the subsections below. Selection Properties are
 only considered during establishment, and can not be changed after a Connection
 is established; however, they can still be read. The return type of a read
 Selection Property is Boolean, where `true` means that the Selection Property

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1003,16 +1003,11 @@ from an antecedent via cloning; see {{groups}} for more.
 {{connection-props}} provides a list of Connection Properties, while Selection
 Properties are listed in the subsections below. Selection Properties are
 only considered during establishment, and can not be changed after a Connection
-is established; however, they can still be read. The return type of a read
-Selection Property is Boolean, where `true` means that the Selection Property
-has been applied and `false` means that the Selection Property has not
-been applied. Note that `true` does not mean that a request has been honored.
-For example, if `Congestion control` was
-requested with preference level `Prefer`, but congestion control could not
-be supported, reading the `congestionControl` property yields the
-value `false`. If the preference level `Avoid` was used for `Congestion control`,
-and, as requested, the Connection is not congestion controlled, reading
-the `congestionControl` property also yields the value `false`.
+is established; however, they can still be read. Upon reading, the Preference type
+of a Selection Property changes into Boolean, where where `true` means that the
+Preference was honored and `false` means that it has not been honored (implementations
+of Transport Services systems may alternatively use the two Preference values `Require`
+and `Prohibit` to represent `true` and `false`, respectively).
 
 An implementation of the Transport Services API must provide sensible defaults for Selection
 Properties. The default values for each property below represent a


### PR DESCRIPTION
Resolves #1012.

- @benthor wrote: "Why is the text talking about "many properties" that can no longer be changed, instead of relying on the earlier, nice and clear distinction between Selection and Connection Properties?". => In line with the suggestion from @theri, this is now changed, it says Selection Properties.
- @benthor wrote: "Where earlier, Selection Properties were said to remain readable, now they are only queryable?". =>  In line with @theri's answer, this PR replaces "query" with "read" in this text.
- @benthor wrote: "Are "applied" Selection Properties still Selection Properties? Shouldn't they better be referred to using a different term?"  and here, @theri suggested: "In the [Architecture doc](https://www.ietf.org/archive/id/draft-ietf-taps-arch-12.html#name-transport-services-implemen), we define Protocol Stack as a Transport Services implementation concept, and we talk about a certain protocol stacks providing certain features (see [Transport Features defined in the minset RFC 8923](https://www.rfc-editor.org/rfc/rfc8923). Perhaps we could rephrase this part of the API draft to use that terminology, e.g., the application can query the actually used protocol stack and then know which Transport Features it supports."   => I don't know how to apply this change, and it generally sounds a bit complicated to me. I think that Selection Properties should keep their name.
- Regarding the confusing text with the `congestion control` example, I removed this and I think it makes things clearer.

Regarding the return type, I think I now finally understood the bigger problem. Returning a Boolean instead of a Preference should make sense and should be easy to implement (as also described in this PR). The problem is that not *all* Selection Properties are of type Preference. E.g., `multipath` is an enumeration, representing `disabled`, `active` or `passive`. What sense does it make if this becomes only `true` or `false`?  Similarly, `interface` and `pvd` are of type "Collection of (Preference, Enumeration)", and indeed it would make sense to expect a Collection of booleans, not a singular boolean.

This PR now explicitly says that, upon reading, the *Preference type* of a Selection Property (not the whole Selection Property!) changes into Boolean.