### PR TITLE
Sketch alternative multicast model – #1021 reloaded

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -867,70 +867,69 @@ LocalSpecifier.WithStunServer(address, port, credentials)
 
 ### Multicast Examples {#multicast-examples}
 
-Specify a Local Endpoint using an Any-Source Multicast group to join on a named local interface:
+The following examples show how multicast groups can be used.
+
+Join an Any-Source Multicast group in receive-only mode, bound to a known
+port on a named local interface:
 
 ~~~
-LocalSpecifier := NewLocalEndpoint()
-LocalSpecifier.WithIPv4Address(233.252.0.0)
-LocalSpecifier.WithInterface("en0")
+   RemoteSpecifier := NewRemoteEndpoint()
+   RemoteSpecifier.WithIPv4Address(233.252.0.0)
+
+   LocalSpecifier := NewLocalEndpoint()
+   LocalSpecifier.WithPort(5353)
+   LocalSpecifier.WithInterface("en0")
+
+   TransportProperties := ...
+   SecurityParameters  := ...
+
+   Preconnection := newPreconnection(LocalSpecifier,
+                                     RemoteSpecifier,
+                                     TransportProperties,
+                                     SecurityProperties)
+   Listener := Preconnection.Listen()
 ~~~
 
-Source-Specific Multicast requires setting both a Local and Remote Endpoint:
+Create a Source-Specific Multicast group as a sender:
 
 ~~~
-LocalSpecifier := NewLocalEndpoint()
-LocalSpecifier.WithIPv4Address(232.1.1.1)
-LocalSpecifier.WithInterface("en0")
+   RemoteSpecifier := NewRemoteEndpoint()
+   RemoteSpecifier.WithIPv4Address(232.1.1.1)
 
-RemoteSpecifier := NewRemoteEndpoint()
-RemoteSpecifier.WithIPv4Address(192.0.2.22)
+   LocalSpecifier := NewLocalEndpoint()
+   LocalSpecifier.WithIPv4Address(192.0.2.22)
+   RemoteSpecifier.WithInterface("en0")
+
+   TransportProperties := ...
+   SecurityParameters  := ...
+
+   Preconnection := newPreconnection(LocalSpecifier,
+                                     RemoteSpecifier,
+                                     TransportProperties,
+                                     SecurityProperties)
+   Connection := Preconnection.Initiate()
 ~~~
 
-One common pattern for multicast is to both send and receive multicast. For such
-cases, an application can set up both a Listener and a Connection. The Listener
-is only used to accept Connections that receive inbound multicast. The initiated
-Connection is only used to send multicast.
+Join an any-source multicast group as both a sender and a receiver:
 
 ~~~
-// Prepare multicast Listener
-LocalMulticastSpecifier := NewLocalEndpoint()
-LocalMulticastSpecifier.WithIPv4Address(233.252.0.0)
-LocalMulticastSpecifier.WithPort(5353)
-LocalMulticastSpecifier.WithInterface("en0")
+   RemoteSpecifier := NewRemoteEndpoint()
+   RemoteSpecifier.WithIPv4Address(233.252.0.0)
+   RemoteSpecifier.WithPort(5353)
+   RemoteSpecifier.WithInterface("en0")
 
-TransportProperties := NewTransportProperties()
-TransportProperties.Require(preserve-msg-boundaries)
-// Reliable Data Transfer and Preserve Order are Required by default
-                                  
-// Specifying a Remote Endpoint is optional when using Listen()
-Preconnection := NewPreconnection(LocalMulticastSpecifier,
-                                  TransportProperties,
-                                  SecurityParameters)
+   LocalSpecifier := NewLocalEndpoint()
+   LocalSpecifier.WithIPv4Address(192.0.2.22)
+   LocalSpecifier.WithPort(5353)
 
-MulticastListener := Preconnection.Listen()
+   TransportProperties := ...
+   SecurityParameters  := ...
 
-// Handle inbound messages sent to the multicast group
-MulticastListener -> ConnectionReceived<MulticastReceiverConnection>
-MulticastReceiverConnection.Receive()
-MulticastReceiverConnection -> Received<messageDataRequest, messageContext>
-
-// Prepare Connection to send multicast
-LocalSpecifier := NewLocalEndpoint()
-LocalSpecifier.WithPort(5353)
-LocalSpecifier.WithInterface("en0")
-RemoteMulticastSpecifier := NewRemoteEndpoint()
-RemoteMulticastSpecifier.WithIPv4Address(233.252.0.0)
-RemoteMulticastSpecifier.WithPort(5353)
-RemoteMulticastSpecifier.WithInterface("en0")
-
-Preconnection2 := NewPreconnection(LocalSpecifier,
-                                   RemoteMulticastSpecifier,
-                                   TransportProperties,
-                                   SecurityParameters)
-                                   
-// Send outbound messages to the multicast group
-MulticastSenderConnection := Preconnection.Initiate()
-MulticastSenderConnection.Send(messageData)
+   Preconnection := newPreconnection(LocalSpecifier,
+                                     RemoteSpecifier,
+                                     TransportProperties,
+                                     SecurityProperties)
+   Connection, Listener := Preconnection.Rendezvous()
 ~~~
 
 ## Specifying Transport Properties {#selection-props}

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -738,7 +738,7 @@ early binding when required, for example with some Network Address Translator
 ### Using Multicast Endpoints
 
 To use multicast, a Preconnection is first created with the Local/Remote Endpoint
-specifying the ASN/SSN multicast group and destination port number.
+specifying the ASM/SSM multicast group and destination port number.
 
 Calling Initiate() on that Preconnection creates a Connection that can be
 used to send messages to the multicast group. The Connection object that is

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -794,7 +794,6 @@ LocalSpecifier.WithTTL(TTL)
 
 See {{multicast-examples}} for more examples.
 
-
 ### Constraining Interfaces for Endpoints {#ifspec}
 
 Note that this API has multiple ways to constrain and prioritize endpoint candidates based on the network interface:

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -738,7 +738,7 @@ early binding when required, for example with some Network Address Translator
 ### Using Multicast Endpoints
 
 To use multicast, a Preconnection is first created with the Local/Remote Endpoint
-specifying the _any source multicast (ASM)_ / _source specific multicast (SSM)_ multicast group and destination port number.
+specifying the any-source multicast (ASM) or source-specific multicast (SSM) multicast group and destination port number.
 
 Calling Initiate() on that Preconnection creates a Connection that can be
 used to send messages to the multicast group. The Connection object that is

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -762,6 +762,7 @@ Endpoint will join the multicast group to receive messages. This Listener
 will create one Connection for each Remote Endpoint sending to the group,
 with the Local Endpoint set to the group address. The set of Connection
 objects created forms a Connection Group.
+The receiving interface can be restricted by passing it as part of the LocalSpecifier or queried through the MessagContext on the messages received (see {{msg-ctx}} for further details).
 
 ```
 LocalSpecifier.WithSingleSourceMulticastGroupIPv4(GroupAddress, SourceAddress)

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -737,14 +737,8 @@ early binding when required, for example with some Network Address Translator
 
 ### Using Multicast Endpoints
 
-To use multicast, a Preconnection is first created with the Remote Endpoint
-specifying the multicast group and destination port number.
-
-```
-RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
-RemoteSpecifier.WithIPv6MulticastGroup(FF0X::DB8:0:0)
-LocalSpecifier.WithPort(5353)
-```
+To use multicast, a Preconnection is first created with the Local/Remote Endpoint
+specifying the multicast group and destination port number and whether ASN/SSN is intended.
 
 Calling Initiate() on that Preconnection creates a Connection that can be
 used to send messages to the multicast group. The Connection object that is
@@ -754,11 +748,23 @@ Connection will have a Local Endpoint indicating the local interface to
 which the connection is bound and a Remote Endpoint indicating the
 multicast group.
 
+```
+RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
+RemoteSpecifier.WithIPv6MulticastGroup(FF0X::DB8:0:0)
+RemoteSpecifier.WithPort(5353)
+```
+
 Calling Listen() on a Preconnection with a multicast group specified on the Remote
 Endpoint will join the multicast group to receive messages. This Listener
 will create one Connection for each Remote Endpoint sending to the group,
 with the Local Endpoint set to the group address. The set of Connection
 objects created forms a Connection Group.
+
+```
+LocalSpecifier.WithIPv4MulticastGroup(233.252.0.0, (ASN|SSN))
+LocalSpecifier.WithIPv6MulticastGroup(FF0X::DB8:0:0, (ASN|SSN))
+LocalSpecifier.WithPort(5353)
+```
 
 Calling Rendezvous() on a Preconnection with an any-source multicast group
 address as the Remote Endpoint will join the multicast group, and also
@@ -768,10 +774,17 @@ can be used to send to the group, that acts the same as a connection
 returned by calling Initiate() with a multicast Remote Endpoint, and a
 Listener that acts as if Listen() had been called with a multicast Remote
 Endpoint.
-
 Calling Rendezvous() on a Preconnection with a source-specific multicast
-group address as the Remote Endpoint results in an EstablishmentError.
+group address as the Local Endpoint results in an EstablishmentError.
 
+```
+RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
+RemoteSpecifier.WithIPv6MulticastGroup(FF0X::DB8:0:0)
+RemoteSpecifier.WithPort(5353)
+LocalSpecifier.WithIPv4MulticastGroup(233.252.0.0, ASN)
+LocalSpecifier.WithIPv6MulticastGroup(FF0X::DB8:0:0, ASN)
+LocalSpecifier.WithPort(5353)
+```
 
 See {{multicast-examples}} for more examples.
 
@@ -880,9 +893,9 @@ port on a named local interface:
 
 ~~~
    RemoteSpecifier := NewRemoteEndpoint()
-   RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
 
    LocalSpecifier := NewLocalEndpoint()
+   LocalSpecifier.WithIPv4MulticastGroup(233.252.0.0, ASN)
    LocalSpecifier.WithPort(5353)
    LocalSpecifier.WithInterface("en0")
 
@@ -901,10 +914,10 @@ port on a named local interface:
 
 ~~~
    RemoteSpecifier := NewRemoteEndpoint()
-   RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
    RemoteSpecifier.WithIPv4Address(198.51.100.10)
 
    LocalSpecifier := NewLocalEndpoint()
+   LocalSpecifier.WithIPv4MulticastGroup(233.252.0.0, SSN)
    LocalSpecifier.WithPort(5353)
    LocalSpecifier.WithInterface("en0")
 
@@ -927,7 +940,7 @@ Create a Source-Specific Multicast group as a sender:
 
    LocalSpecifier := NewLocalEndpoint()
    LocalSpecifier.WithIPv4Address(192.0.2.22)
-   RemoteSpecifier.WithInterface("en0")
+   LocalSpecifier.WithInterface("en0")
 
    TransportProperties := ...
    SecurityParameters  := ...
@@ -948,6 +961,7 @@ Join an any-source multicast group as both a sender and a receiver:
    RemoteSpecifier.WithInterface("en0")
 
    LocalSpecifier := NewLocalEndpoint()
+   LocalSpecifier.WithIPv4MulticastGroup(233.252.0.0, ASN)
    LocalSpecifier.WithIPv4Address(192.0.2.22)
    LocalSpecifier.WithPort(5353)
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -738,7 +738,7 @@ early binding when required, for example with some Network Address Translator
 ### Using Multicast Endpoints
 
 To use multicast, a Preconnection is first created with the Remote Endpoint
-specifying the multicast group and destination port number. 
+specifying the multicast group and destination port number.
 
 Calling Initiate() on that Preconnection creates a Connection that can be
 used to send messages to the multicast group. The Connection object that is

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -752,6 +752,7 @@ multicast group.
 RemoteSpecifier.WithMulticastGroupIPv4(GroupAddress)
 RemoteSpecifier.WithMulticastGroupIPv6(GroupAddress)
 RemoteSpecifier.WithPort(PortNumber)
+RemoteSpecifier.WithTTL(TTL)
 ```
 
 Calling Listen() on a Preconnection with a multicast group specified on the Remote
@@ -766,6 +767,7 @@ LocalSpecifier.WithSingleSourceMulticastGroupIPv6(GroupAddress, SourceAddress)
 LocalSpecifier.WithAnySourceMulticastGroupIPv4(GroupAddress)
 LocalSpecifier.WithAnySourceMulticastGroupIPv6(GroupAddress)
 LocalSpecifier.WithPort(PortNumber)
+LocalSpecifier.WithTTL(TTL)
 ```
 
 Calling Rendezvous() on a Preconnection with an any-source multicast group
@@ -783,9 +785,11 @@ group address as the Local Endpoint results in an EstablishmentError.
 RemoteSpecifier.WithMulticastGroupIPv4(GroupAddress)
 RemoteSpecifier.WithMulticastGroupIPv6(GroupAddress)
 RemoteSpecifier.WithPort(PortNumber)
+RemoteSpecifier.WithTTL(TTL)
 LocalSpecifier.WithAnySourceMulticastGroupIPv4(GroupAddress)
 LocalSpecifier.WithAnySourceMulticastGroupIPv6(GroupAddress)
 LocalSpecifier.WithPort(PortNumber)
+LocalSpecifier.WithTTL(TTL)
 ```
 
 See {{multicast-examples}} for more examples.
@@ -938,6 +942,7 @@ Create a Source-Specific Multicast group as a sender:
    RemoteSpecifier := NewRemoteEndpoint()
    RemoteSpecifier.WithMulticastGroupIPv4(232.1.1.1)
    RemoteSpecifier.WithPort(5353)
+   RemoteSpecifier.WithTTL(8)
 
    LocalSpecifier := NewLocalEndpoint()
    LocalSpecifier.WithIPv4Address(192.0.2.22)
@@ -959,12 +964,14 @@ Join an any-source multicast group as both a sender and a receiver:
    RemoteSpecifier := NewRemoteEndpoint()
    RemoteSpecifier.WithMulticastGroupIPv4(233.252.0.0)
    RemoteSpecifier.WithPort(5353)
-   RemoteSpecifier.WithInterface("en0")
+   RemoteSpecifier.WithTTL(8)
 
    LocalSpecifier := NewLocalEndpoint()
    LocalSpecifier.WithAnySourceMulticastGroupIPv4(233.252.0.0)
    LocalSpecifier.WithIPv4Address(192.0.2.22)
    LocalSpecifier.WithPort(5353)
+   LocalSpecifier.WithInterface("en0")
+
 
    TransportProperties := ...
    SecurityParameters  := ...

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -748,6 +748,8 @@ Connection will have a Local Endpoint indicating the local interface to
 which the connection is bound and a Remote Endpoint indicating the
 multicast group.
 
+The following API calls can be used to configure a Preconnection before calling Initiate():
+
 ```
 RemoteSpecifier.WithMulticastGroupIPv4(GroupAddress)
 RemoteSpecifier.WithMulticastGroupIPv6(GroupAddress)

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -748,7 +748,7 @@ Connection will have a Local Endpoint indicating the local interface to
 which the connection is bound and a Remote Endpoint indicating the
 multicast group.
 
-Calling Listen() on a Preconnection with a multicast group as the Remote
+Calling Listen() on a Preconnection with a multicast group specified on the Remote
 Endpoint will join the multicast group to receive messages. This Listener
 will create one Connection for each Remote Endpoint sending to the group,
 with the Local Endpoint set to the group address. The set of Connection
@@ -874,7 +874,7 @@ port on a named local interface:
 
 ~~~
    RemoteSpecifier := NewRemoteEndpoint()
-   RemoteSpecifier.WithIPv4Address(233.252.0.0)
+   RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
 
    LocalSpecifier := NewLocalEndpoint()
    LocalSpecifier.WithPort(5353)
@@ -894,7 +894,7 @@ Create a Source-Specific Multicast group as a sender:
 
 ~~~
    RemoteSpecifier := NewRemoteEndpoint()
-   RemoteSpecifier.WithIPv4Address(232.1.1.1)
+   RemoteSpecifier.WithIPv4MulticastGroup(232.1.1.1)
 
    LocalSpecifier := NewLocalEndpoint()
    LocalSpecifier.WithIPv4Address(192.0.2.22)
@@ -914,7 +914,7 @@ Join an any-source multicast group as both a sender and a receiver:
 
 ~~~
    RemoteSpecifier := NewRemoteEndpoint()
-   RemoteSpecifier.WithIPv4Address(233.252.0.0)
+   RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
    RemoteSpecifier.WithPort(5353)
    RemoteSpecifier.WithInterface("en0")
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -738,7 +738,7 @@ early binding when required, for example with some Network Address Translator
 ### Using Multicast Endpoints
 
 To use multicast, a Preconnection is first created with the Local/Remote Endpoint
-specifying the multicast group and destination port number and whether ASN/SSN is intended.
+specifying the ASN/SSN multicast group and destination port number.
 
 Calling Initiate() on that Preconnection creates a Connection that can be
 used to send messages to the multicast group. The Connection object that is
@@ -749,9 +749,9 @@ which the connection is bound and a Remote Endpoint indicating the
 multicast group.
 
 ```
-RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
-RemoteSpecifier.WithIPv6MulticastGroup(FF0X::DB8:0:0)
-RemoteSpecifier.WithPort(5353)
+RemoteSpecifier.WithMulticastGroupIPv4(GroupAddress)
+RemoteSpecifier.WithMulticastGroupIPv6(GroupAddress)
+RemoteSpecifier.WithPort(PortNumber)
 ```
 
 Calling Listen() on a Preconnection with a multicast group specified on the Remote
@@ -761,9 +761,11 @@ with the Local Endpoint set to the group address. The set of Connection
 objects created forms a Connection Group.
 
 ```
-LocalSpecifier.WithIPv4MulticastGroup(233.252.0.0, (ASN|SSN))
-LocalSpecifier.WithIPv6MulticastGroup(FF0X::DB8:0:0, (ASN|SSN))
-LocalSpecifier.WithPort(5353)
+LocalSpecifier.WithSingleSourceMulticastGroupIPv4(GroupAddress, SourceAddress)
+LocalSpecifier.WithSingleSourceMulticastGroupIPv6(GroupAddress, SourceAddress)
+LocalSpecifier.WithAnySourceMulticastGroupIPv4(GroupAddress)
+LocalSpecifier.WithAnySourceMulticastGroupIPv6(GroupAddress)
+LocalSpecifier.WithPort(PortNumber)
 ```
 
 Calling Rendezvous() on a Preconnection with an any-source multicast group
@@ -778,12 +780,12 @@ Calling Rendezvous() on a Preconnection with a source-specific multicast
 group address as the Local Endpoint results in an EstablishmentError.
 
 ```
-RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
-RemoteSpecifier.WithIPv6MulticastGroup(FF0X::DB8:0:0)
-RemoteSpecifier.WithPort(5353)
-LocalSpecifier.WithIPv4MulticastGroup(233.252.0.0, ASN)
-LocalSpecifier.WithIPv6MulticastGroup(FF0X::DB8:0:0, ASN)
-LocalSpecifier.WithPort(5353)
+RemoteSpecifier.WithMulticastGroupIPv4(GroupAddress)
+RemoteSpecifier.WithMulticastGroupIPv6(GroupAddress)
+RemoteSpecifier.WithPort(PortNumber)
+LocalSpecifier.WithAnySourceMulticastGroupIPv4(GroupAddress)
+LocalSpecifier.WithAnySourceMulticastGroupIPv6(GroupAddress)
+LocalSpecifier.WithPort(PortNumber)
 ```
 
 See {{multicast-examples}} for more examples.
@@ -895,7 +897,7 @@ port on a named local interface:
    RemoteSpecifier := NewRemoteEndpoint()
 
    LocalSpecifier := NewLocalEndpoint()
-   LocalSpecifier.WithIPv4MulticastGroup(233.252.0.0, ASN)
+   LocalSpecifier.WithAnySourceMulticastGroupIPv4(233.252.0.0)
    LocalSpecifier.WithPort(5353)
    LocalSpecifier.WithInterface("en0")
 
@@ -914,10 +916,9 @@ port on a named local interface:
 
 ~~~
    RemoteSpecifier := NewRemoteEndpoint()
-   RemoteSpecifier.WithIPv4Address(198.51.100.10)
 
    LocalSpecifier := NewLocalEndpoint()
-   LocalSpecifier.WithIPv4MulticastGroup(233.252.0.0, SSN)
+   LocalSpecifier.WithSingleSourceMulticastGroupIPv4(233.252.0.0, 198.51.100.10)
    LocalSpecifier.WithPort(5353)
    LocalSpecifier.WithInterface("en0")
 
@@ -935,7 +936,7 @@ Create a Source-Specific Multicast group as a sender:
 
 ~~~
    RemoteSpecifier := NewRemoteEndpoint()
-   RemoteSpecifier.WithIPv4MulticastGroup(232.1.1.1)
+   RemoteSpecifier.WithMulticastGroupIPv4(232.1.1.1)
    RemoteSpecifier.WithPort(5353)
 
    LocalSpecifier := NewLocalEndpoint()
@@ -956,12 +957,12 @@ Join an any-source multicast group as both a sender and a receiver:
 
 ~~~
    RemoteSpecifier := NewRemoteEndpoint()
-   RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
+   RemoteSpecifier.WithMulticastGroupIPv4(233.252.0.0)
    RemoteSpecifier.WithPort(5353)
    RemoteSpecifier.WithInterface("en0")
 
    LocalSpecifier := NewLocalEndpoint()
-   LocalSpecifier.WithIPv4MulticastGroup(233.252.0.0, ASN)
+   LocalSpecifier.WithAnySourceMulticastGroupIPv4(233.252.0.0)
    LocalSpecifier.WithIPv4Address(192.0.2.22)
    LocalSpecifier.WithPort(5353)
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -737,7 +737,7 @@ early binding when required, for example with some Network Address Translator
 
 ### Using Multicast Endpoints
 
-When using multicast the Remote Endpoint will indicate the multicast group
+When using multicast, the Remote Endpoint will indicate the multicast group
 and destination port number. The Local Endpoint, if specified, will indicate
 the local interface address and port.
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -737,40 +737,34 @@ early binding when required, for example with some Network Address Translator
 
 ### Using Multicast Endpoints
 
-When using multicast, the Remote Endpoint will indicate the multicast group
-and destination port number. The Local Endpoint, if specified, will indicate
-the local interface address and port.
+To use multicast, a Preconnection is first created with the Remote Endpoint
+specifying the multicast group and destination port number. 
 
-Calling Initiate() with a multicast Remote Endpoint will indicate that the
-resulting connection will be used to send multicast messages, and that the
-Preconnection will support Initiate() but not Listen(). Any Connections
-created this way are send-only, and do not join the multicast group. The
-resulting Connection will have a Local Endpoint indicating the local
-interface to which the connection is bound and a Remote Endpoint indicating
-the multicast group.
+Calling Initiate() on that Preconnection creates a Connection that can be
+used to send messages to the multicast group. The Connection object that is
+created will support Send() but not Receive(). Any Connections created this
+way are send-only, and do not join the multicast group. The resulting
+Connection will have a Local Endpoint indicating the local interface to
+which the connection is bound and a Remote Endpoint indicating the
+multicast group.
 
-Calling Listen() with a multicast Remote Endpoint will cause the Transport
-Services system to register for receiving multicast, such as issuing an
-IGMP join {{?RFC3376}} or using MLD for IPV6 {{?RFC4604}}. Any Connections
-that are accepted from this Listener are receive-only.
-The result will be a Connection Group, where each Connection in the group
-has a Local Endpoint indicating the multicast group, and a Remote Endpoint
-denoting the sender of the packet.
+Calling Listen() on a Preconnection with a multicast group as the Remote
+Endpoint will join the multicast group to receive messages. This Listener
+will create one Connection for each Remote Endpoint sending to the group,
+with the Local Endpoint set to the group address. The set of Connection
+objects created forms a Connection Group.
 
-Calling Rendezvous() with an any-source multicast group address as the
-Remote Endpoint will cause the Transport Services system to register for
-receiving multicast, such as issuing an IGMP join {{?RFC3376}} or using MLD
-for IPV6 {{?RFC4604}}, and will also indicate that the resulting connection
-can be used to send multicast messages. 
-The result will be a Connection Group, where first connection in the group
-will have a Local Endpoint indicating the local interface to which the
-connection is bound and a Remote Endpoint indicating the multicast group,
-and each subsequent Connection in the group will have a Local Endpoint
-indicating the multicast group, and a Remote Endpoint denoting the sender
-of the packet.
+Calling Rendezvous() on a Preconnection with an any-source multicast group
+address as the Remote Endpoint will join the multicast group, and also
+indicates that the resulting connection can be used to send messages to the
+multicast group. The Rendezvous() call will return both a Connection that
+can be used to send to the group, that acts the same as a connection
+returned by calling Initiate() with a multicast Remote Endpoint, and a
+Listener that acts as if Listen() had been called with a multicast Remote
+Endpoint.
 
-Calling Rendezvous() with a source-specific multicast group address as the
-remote endpoint results in an EstablishmentError.
+Calling Rendezvous() on a Preconnection with a source-specific multicast
+group address as the Remote Endpoint results in an EstablishmentError.
 
 
 See {{multicast-examples}} for more examples.

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -737,22 +737,44 @@ early binding when required, for example with some Network Address Translator
 
 ### Using Multicast Endpoints
 
-Specifying a multicast group address on a Local Endpoint will indicate to the Transport
-Services system that the resulting connection will be used to receive multicast messages. The
-Remote Endpoint can be used to filter incoming multicast from specific senders. Such
-a Preconnection will only support calling Listen(), not Initiate(). Calling Listen()
-will cause the Transport Services system to register for receiving multicast, such
-as issuing an IGMP join {{?RFC3376}} or using MLD for IPV6 {{?RFC4604}}. Any Connections
+When using multicast the Remote Endpoint will indicate the multicast group
+and destination port number. The Local Endpoint, if specified, will indicate
+the local interface address and port.
+
+Calling Initiate() with a multicast Remote Endpoint will indicate that the
+resulting connection will be used to send multicast messages, and that the
+Preconnection will support Initiate() but not Listen(). Any Connections
+created this way are send-only, and do not join the multicast group. The
+resulting Connection will have a Local Endpoint indicating the local
+interface to which the connection is bound and a Remote Endpoint indicating
+the multicast group.
+
+Calling Listen() with a multicast Remote Endpoint will cause the Transport
+Services system to register for receiving multicast, such as issuing an
+IGMP join {{?RFC3376}} or using MLD for IPV6 {{?RFC4604}}. Any Connections
 that are accepted from this Listener are receive-only.
+The result will be a Connection Group, where each Connection in the group
+has a Local Endpoint indicating the multicast group, and a Remote Endpoint
+denoting the sender of the packet.
 
-Similarly, specifying a multicast group address on the Remote Endpoint will indicate that the
-resulting connection will be used to send multicast messages, and that the Preconnection will
-support Initiate() but not Listen(). Any Connections created this way are send-only.
+Calling Rendezvous() with an any-source multicast group address as the
+Remote Endpoint will cause the Transport Services system to register for
+receiving multicast, such as issuing an IGMP join {{?RFC3376}} or using MLD
+for IPV6 {{?RFC4604}}, and will also indicate that the resulting connection
+can be used to send multicast messages. 
+The result will be a Connection Group, where first connection in the group
+will have a Local Endpoint indicating the local interface to which the
+connection is bound and a Remote Endpoint indicating the multicast group,
+and each subsequent Connection in the group will have a Local Endpoint
+indicating the multicast group, and a Remote Endpoint denoting the sender
+of the packet.
 
-A Rendezvous() call on Preconnections containing group addresses results in an
-EstablishmentError as described in {{rendezvous}}.
+Calling Rendezvous() with a source-specific multicast group address as the
+remote endpoint results in an EstablishmentError.
+
 
 See {{multicast-examples}} for more examples.
+
 
 ### Constraining Interfaces for Endpoints {#ifspec}
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -740,6 +740,12 @@ early binding when required, for example with some Network Address Translator
 To use multicast, a Preconnection is first created with the Remote Endpoint
 specifying the multicast group and destination port number.
 
+```
+RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
+RemoteSpecifier.WithIPv6MulticastGroup(FF0X::DB8:0:0)
+LocalSpecifier.WithPort(5353)
+```
+
 Calling Initiate() on that Preconnection creates a Connection that can be
 used to send messages to the multicast group. The Connection object that is
 created will support Send() but not Receive(). Any Connections created this
@@ -890,11 +896,34 @@ port on a named local interface:
    Listener := Preconnection.Listen()
 ~~~
 
+Join an Source-Specific Multicast group in receive-only mode, bound to a known
+port on a named local interface:
+
+~~~
+   RemoteSpecifier := NewRemoteEndpoint()
+   RemoteSpecifier.WithIPv4MulticastGroup(233.252.0.0)
+   RemoteSpecifier.WithIPv4Address(198.51.100.10)
+
+   LocalSpecifier := NewLocalEndpoint()
+   LocalSpecifier.WithPort(5353)
+   LocalSpecifier.WithInterface("en0")
+
+   TransportProperties := ...
+   SecurityParameters  := ...
+
+   Preconnection := newPreconnection(LocalSpecifier,
+                                     RemoteSpecifier,
+                                     TransportProperties,
+                                     SecurityProperties)
+   Listener := Preconnection.Listen()
+~~~
+
 Create a Source-Specific Multicast group as a sender:
 
 ~~~
    RemoteSpecifier := NewRemoteEndpoint()
    RemoteSpecifier.WithIPv4MulticastGroup(232.1.1.1)
+   RemoteSpecifier.WithPort(5353)
 
    LocalSpecifier := NewLocalEndpoint()
    LocalSpecifier.WithIPv4Address(192.0.2.22)

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -738,7 +738,7 @@ early binding when required, for example with some Network Address Translator
 ### Using Multicast Endpoints
 
 To use multicast, a Preconnection is first created with the Local/Remote Endpoint
-specifying the ASM/SSM multicast group and destination port number.
+specifying the _any source multicast (ASM)_ / _source specific multicast (SSM)_ multicast group and destination port number.
 
 Calling Initiate() on that Preconnection creates a Connection that can be
 used to send messages to the multicast group. The Connection object that is


### PR DESCRIPTION
This is a remake of #1021 as @GrumpyOldTroll suggested.
It moves the WithIPvXMulticastGroup for receiving to the LocalEndpoint and adds the ASM/SSM distinguisher.
It does not add TTL support.