### PR TITLE
Terminology alignment and consistent coverage of actions and events

### DIFF
--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -1140,11 +1140,6 @@ ConnectionReceived:
 Clone:
 : Calling `Clone` on an SCTP association creates a new Connection object and assigns it a new stream id in accordance with the stream id assignment procedure described above. If there are not enough streams available, ADD_STREAM.SCTP must be called.
 
-Priority (Connection):
-: When this value is changed, or a Message with Message Property `msgPriority` is sent, and there are multiple
-Connection objects assigned to the same SCTP association,
-CONFIGURE_STREAM_SCHEDULER.SCTP is called to adjust the priorities of streams in the SCTP association.
-
 Send:
 : SEND.SCTP. Message Properties such as `msgLifetime` and `msgOrdered` map to parameters of this primitive.
 
@@ -1162,6 +1157,9 @@ Calling `CloseGroup` calls CLOSE.SCTP, closing all Connections in the SCTP assoc
 
 AbortGroup:
 Calling `AbortGroup` calls ABORT.SCTP, immediately closing all Connections in the SCTP association.
+
+In addition to the API mappings described above, when there are multiple Connection objects assigned to the same SCTP association, SCTP can support Connection properties such as `connPriority`and `connScheduler` where CONFIGURE_STREAM_SCHEDULER.SCTP can be called to adjust the priorities of streams in the SCTP association.
+
 
 # IANA Considerations
 

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -1011,7 +1011,7 @@ Close:
 : Calling `Close` on a UDP Connection (ABORT.UDP(-Lite)) releases the local port reservation.
 
 Abort:
-: Calling `Abort` on a UDP Connection (ABORT.UDP(-Lite)) is identical to calling `Close`except that a ConnectionErrror Event rather than a Closed Event will be sent by the Connection.
+: Calling `Abort` on a UDP Connection (ABORT.UDP(-Lite)) is identical to calling `Close`, except that the Connection will send a ConnectionError Event rather than a Closed Event.
 
 CloseGroup:
 : Calling `CloseGroup` on a UDP Connection (ABORT.UDP(-Lite)) is identical to calling `Close` on this Connection and on all Connections in the same ConnectionGroup.
@@ -1159,7 +1159,6 @@ AbortGroup:
 Calling `AbortGroup` calls ABORT.SCTP, immediately closing all Connections in the SCTP association.
 
 In addition to the API mappings described above, when there are multiple Connection objects assigned to the same SCTP association, SCTP can support Connection properties such as `connPriority`and `connScheduler` where CONFIGURE_STREAM_SCHEDULER.SCTP can be called to adjust the priorities of streams in the SCTP association.
-
 
 # IANA Considerations
 

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -963,7 +963,7 @@ Connectedness: Connected
 
 Data Unit: Byte-stream
 
-the Transport Services API mappings for MPTCP are identical to TCP. MPTCP adds support for multipath properties,
+The Transport Services API mappings for MPTCP are identical to TCP. MPTCP adds support for multipath properties,
 such as `multipath` and `multipathPolicy`.
 
 ## UDP


### PR DESCRIPTION
This PR covers steps 1 and 2 in #608. When aligning the error events for UDP multicast I also noticed that the text for UDP was not correct as soft errors do not generate ConnectionError events so also attempted to fix this.