### PR TITLE
Updates the description for UDP-Lite.

### DIFF
--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -1025,9 +1025,7 @@ Connectedness: Connectionless
 
 Data Unit: Datagram
 
-The Transport Services API mappings for UDP-Lite are identical to UDP. Properties that require checksum coverage are not supported
-by UDP-Lite, such as `msgChecksumLen`, `fullChecksumSend`,
-`recvChecksumLen`, and `fullChecksumRecv`.
+The Transport Services API mappings for UDP-Lite are identical to UDP. In addition, UDP-Lite supports the `msgChecksumLen` and `recvChecksumLen` Properties that allow an  application to specify the minimum number of bytes in a message that need to be covered by a checksum.
 
 ## UDP Multicast Receive
 

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -1025,7 +1025,10 @@ Connectedness: Connectionless
 
 Data Unit: Datagram
 
-The Transport Services API mappings for UDP-Lite are identical to UDP. In addition, UDP-Lite supports the `msgChecksumLen` and `recvChecksumLen` Properties that allow an  application to specify the minimum number of bytes in a message that need to be covered by a checksum.
+The Transport Services API mappings for UDP-Lite are identical to UDP. In addition,
+UDP-Lite supports the `msgChecksumLen` and `recvChecksumLen` Properties
+that allow an application to specify the minimum number of bytes in a message that
+need to be covered by a checksum.
 
 ## UDP Multicast Receive
 


### PR DESCRIPTION
Initially I thought the description for UDP-Lite was incomplete, but mapping back to the details of the API draft I realized it was incorrect. UDP-Lite supports the msgChecksumLen and recvChecksumLen properties. 

The API for theses primitives is a bit messy. As specified I think it means the following:
- UDP can use them to set full coverage or no checksum using the special value of 0.
- UDP-Lite can use them to set full coverage or a partial coverage.
- Setting the checksum to only cover the header, although supported by UDP-Lite, will not be possible as 0 is a special value.

The special value of 0 can not be used by UDP-Lite, but I left this detail out of the pull request as I thought it got very detailed. It can be added if you think it is needed.