### PR TITLE
API: default value for "Timeout for keep alive packets".

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -2080,7 +2080,7 @@ Type:
 : Numeric (non-negative) or `Disabled`
 
 Default:
-: Implementation-defined
+: `Disabled`
 
 A Transport Services API can request a protocol that supports sending keep alive packets {{keep-alive}}.
 If this property is Numeric, it specifies the maximum length of time an idle connection (one for which no transport


### PR DESCRIPTION
 Closes #1094.