### PR TITLE
Rename/remove "protocol properties"

### DIFF
--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -765,7 +765,7 @@ Connection Properties. A Connection can also generate events in the form of Soft
 The set of Connection Properties that are supported for setting and getting on a Connection are described in {{I-D.ietf-taps-interface}}. For
 any properties that are generic, and thus could apply to all protocols being used by a Connection, the Transport Services implementation should store the properties
 in storage common to all protocols, and notify all protocol instances in the Protocol Stack whenever the properties have been modified by the application.
-For protocol-specific Properties, such as the User Timeout that applies to TCP, the Transport Services implementation only needs to update the relevant protocol instance.
+For Protocol-specific Properties, such as the User Timeout that applies to TCP, the Transport Services implementation only needs to update the relevant protocol instance.
 
 If an error is encountered in setting a property (for example, if the application tries to set a TCP-specific property on a Connection that is
 not using TCP), the action should fail gracefully. The application may be informed of the error, but the Connection itself should not be terminated.

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -765,7 +765,7 @@ Connection Properties. A Connection can also generate events in the form of Soft
 The set of Connection Properties that are supported for setting and getting on a Connection are described in {{I-D.ietf-taps-interface}}. For
 any properties that are generic, and thus could apply to all protocols being used by a Connection, the Transport Services implementation should store the properties
 in storage common to all protocols, and notify all protocol instances in the Protocol Stack whenever the properties have been modified by the application.
-For protocol-specfic properties, such as the User Timeout that applies to TCP, the Transport Services implementation only needs to update the relevant protocol instance.
+For protocol-specific Properties, such as the User Timeout that applies to TCP, the Transport Services implementation only needs to update the relevant protocol instance.
 
 If an error is encountered in setting a property (for example, if the application tries to set a TCP-specific property on a Connection that is
 not using TCP), the action should fail gracefully. The application may be informed of the error, but the Connection itself should not be terminated.

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -145,8 +145,8 @@ The Transport Services system should have a list of supported protocols availabl
 
 In the following cases, failure should be detected during pre-establishment:
 
-- A request by an application for Protocol Properties that cannot be satisfied by any of the available protocols. For example, if an application requires `perMsgReliability`, but no such feature is available in any protocol on the host running the transport system this should result in an error, e.g., when SCTP is not supported by the operating system.
-- A request by an application for Protocol Properties that are in conflict with each other, i.e., the required and prohibited properties cannot be satisfied by the same protocol. For example, if an application prohibits `reliability` but then requires `perMsgReliability`, this mismatch should result in an error.
+- A request by an application for properties that cannot be satisfied by any of the available protocols. For example, if an application requires `perMsgReliability`, but no such feature is available in any protocol on the host running the transport system this should result in an error, e.g., when SCTP is not supported by the operating system.
+- A request by an application for properties that are in conflict with each other, i.e., the required and prohibited properties cannot be satisfied by the same protocol. For example, if an application prohibits `reliability` but then requires `perMsgReliability`, this mismatch should result in an error.
 
 To avoid allocating resources that are not finally needed, it is important that configuration-time errors fail as early as possible.
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1949,8 +1949,8 @@ permit more specialized protocol features to be used.
 Too much reliance by an application on protocol-specific Properties can significantly reduce the flexibility
 of a transport services implementation to make appropriate
 selection and configuration choices. Therefore, it is RECOMMENDED that
-Protocol Properties are used for properties common across different protocols and that
-Protocol-specific Properties are only used where specific protocols or properties are necessary.
+protocol-specific properties are used for properties common across different protocols and that
+protocol-specific properties are only used where specific protocols or properties are necessary.
 
 The application can set and query Connection Properties on a per-Connection
 basis. Connection Properties that are not read-only can be set during

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -550,10 +550,10 @@ form \[\<Namespace>.\]\<PropertyName\>.
   properties that are not specific to a protocol and are defined in an RFC.
 - Protocol-specific Properties MUST use the protocol acronym as the Namespace (e.g., a
   `tcp` Connection could support a TCP-specific Transport Property, such as the user timeout
-  value, in a protocol-specific property called `tcp.userTimeoutValue` (see {{tcp-uto}}).
+  value, in a protocol-specific Property called `tcp.userTimeoutValue` (see {{tcp-uto}}).
 - Vendor or implementation specific properties MUST use a string identifying
   the vendor or implementation as the Namespace.
-- For IETF protocols, the name of a Protocol-specific Property SHOULD be specified in an IETF document published in the RFC Series.
+- For IETF protocols, the name of a protocol-specific Property SHOULD be specified in an IETF document published in the RFC Series.
 
 Namespaces for each of the keywords provided in the IANA protocol numbers registry
 (see https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml) are reserved
@@ -1838,7 +1838,7 @@ to the new Connection when calling Clone(), but in this case, a later change to 
 other Connections in the same Connection Group.
 
 The optional `connectionProperties` parameter allows passing
-Transport Properties that control the behavior of the underlying stream or connection to be created, e.g., protocol-specific properties to request specific stream IDs for SCTP or QUIC.
+Transport Properties that control the behavior of the underlying stream or connection to be created, e.g., protocol-specific Properties to request specific stream IDs for SCTP or QUIC.
 
 Message Properties set on a Connection also apply only to that Connection.
 
@@ -1949,8 +1949,8 @@ permit more specialized protocol features to be used.
 Too much reliance by an application on protocol-specific Properties can significantly reduce the flexibility
 of a transport services implementation to make appropriate
 selection and configuration choices. Therefore, it is RECOMMENDED that
-protocol-specific properties are used for properties common across different protocols and that
-protocol-specific properties are only used where specific protocols or properties are necessary.
+protocol-specific Properties are used for properties common across different protocols and that
+protocol-specific Properties are only used where specific protocols or properties are necessary.
 
 The application can set and query Connection Properties on a per-Connection
 basis. Connection Properties that are not read-only can be set during

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -550,14 +550,14 @@ form \[\<Namespace>.\]\<PropertyName\>.
   properties that are not specific to a protocol and are defined in an RFC.
 - Protocol-specific Properties MUST use the protocol acronym as the Namespace (e.g., a
   `tcp` Connection could support a TCP-specific Transport Property, such as the user timeout
-  value, in a protocol-specific Property called `tcp.userTimeoutValue` (see {{tcp-uto}}).
+  value, in a Protocol-specific Property called `tcp.userTimeoutValue` (see {{tcp-uto}}).
 - Vendor or implementation specific properties MUST use a string identifying
   the vendor or implementation as the Namespace.
-- For IETF protocols, the name of a protocol-specific Property SHOULD be specified in an IETF document published in the RFC Series.
+- For IETF protocols, the name of a Protocol-specific Property SHOULD be specified in an IETF document published in the RFC Series.
 
 Namespaces for each of the keywords provided in the IANA protocol numbers registry
 (see https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml) are reserved
-for protocol-specific Properties and MUST NOT be used for vendor or implementation-specific properties.
+for Protocol-specific Properties and MUST NOT be used for vendor or implementation-specific properties.
 Avoid using any of the terms listed as keywords in the protocol numbers registry as any part of a vendor- or
 implementation-specific property name.
 
@@ -1838,7 +1838,7 @@ to the new Connection when calling Clone(), but in this case, a later change to 
 other Connections in the same Connection Group.
 
 The optional `connectionProperties` parameter allows passing
-Transport Properties that control the behavior of the underlying stream or connection to be created, e.g., protocol-specific Properties to request specific stream IDs for SCTP or QUIC.
+Transport Properties that control the behavior of the underlying stream or connection to be created, e.g., Protocol-specific Properties to request specific stream IDs for SCTP or QUIC.
 
 Message Properties set on a Connection also apply only to that Connection.
 
@@ -1946,11 +1946,11 @@ Properties are defined in {{connection-props}} below.
 Protocol-specific Properties are defined in a transport- and
 implementation-specific way to
 permit more specialized protocol features to be used.
-Too much reliance by an application on protocol-specific Properties can significantly reduce the flexibility
+Too much reliance by an application on Protocol-specific Properties can significantly reduce the flexibility
 of a transport services implementation to make appropriate
 selection and configuration choices. Therefore, it is RECOMMENDED that
-protocol-specific Properties are used for properties common across different protocols and that
-protocol-specific Properties are only used where specific protocols or properties are necessary.
+Protocol-specific Properties are used for properties common across different protocols and that
+Protocol-specific Properties are only used where specific protocols or properties are necessary.
 
 The application can set and query Connection Properties on a per-Connection
 basis. Connection Properties that are not read-only can be set during
@@ -2432,7 +2432,7 @@ MessageContext.add(property, value)
 PropertyValue := MessageContext.get(property)
 ~~~
 
-These Message Properties may be generic properties or protocol-specific Properties.
+These Message Properties may be generic properties or Protocol-specific Properties.
 
 For MessageContexts returned by send Events (see {{send-events}}) and receive Events (see {{receive-events}}), the application can query information about the Local and Remote Endpoint:
 


### PR DESCRIPTION
Closes #1101.

We don't have "Protocol Properties" - two occurrences in -interface should really refer to "protocol-specific Properties", and two occurrences in -impl should really refer to properties.