### PR TITLE
A glossary?

### DIFF
--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -495,7 +495,7 @@ The following categories of events can be delivered to an application:
 
 A Connection Group is a set of Connections that shares properties and caches. A Connection Group represents state for managing Connections within a single application, and does not require end-to-end protocol signaling. For multiplexing transport protocols, only Connections within the same Connection Group are allowed to be multiplexed together.
 
-When the API clones an existing Connection, this adds a new Connection to the Connection Group. A change to one of the Connection Properties on any Connection in the Connection Group automatically changes the Connection Property for all others. All Connections in a Connection Group share the same set of Connection Properties except for the Connection Priority. These Connection Properties are said to be entangled.
+The API allows a Connection to be created from another Connection.  This adds the new Connection to the Connection Group. A change to one of the Connection Properties on any Connection in the Connection Group automatically changes the Connection Property for all others. All Connections in a Connection Group share the same set of Connection Properties except for the Connection Priority. These Connection Properties are said to be entangled.
 
 For multiplexing transport protocols, only Connections within the same Connection Group are allowed to be multiplexed together. Passive Connections can also be added to a Connection Group, e.g., when a Listener receives a new Connection that is just a new stream of an already active multi-streaming protocol
 instance.

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -113,6 +113,7 @@ they appear in all capitals, as shown here.
 This subsection provides a brief gloassary of key terms related to the architecture. These terms ar defined in the relevent sections of this document.
 
 - Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
+- Clone: A copy of a Connection that forms a part of a Connection Group.
 - Connection: An object that can be used to send and receive messages.
 - Connection Group: A set of Connections that shares properties and caches.
 - Connection Property: A Transport Property that can be used to configure protocol-specific options and control per-connection behavior of a Transport Services implementation.

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -118,7 +118,7 @@ This subsection provides a glossary of key terms related to the Transport Servic
 - Clone: A Connection that was created from another Connection, and forms a part of a Connection Group.
 - Connection: Shared state of two or more Endpoints that persists across Messages that are transmitted and received between these Endpoints {{?RFC8303}}.
 - Connection Group: A set of Connections that shares properties and caches.
-- Connection Property: A Transport Property that can be used to configure protocol-specific options and control per-connection behavior of a Transport Services implementation.
+- Connection Property: A Transport Property that controls per-Connection behavior of a Transport Services implementation.
 - Endpoint: An identifier for one side of a transport connection.
 - Equivalent Protocol Stacks: Protocol stacks that can be safely swapped or raced in parallel during connection establishment.
 - Event: A primitive that is invoked by an Endpoint {{?RFC8303}}.

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -114,7 +114,7 @@ This subsection provides a brief gloassary of key terms related to the architect
 
 - Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
 - Connection: An object that can be used to send and receive messages.
-- Connection Group: A set of Connections that shares properties and caches. 
+- Connection Group: A set of Connections that shares properties and caches.
 - Connection Property: A Transport Property that can be used to configure protocol-specific options and control per-connection behavior of a Transport Services implementation.
 - Endpoint: An identifier for one side of a transport connection.
 - Equivalent Protocol Stacks: Protocol stacks that can be safely swapped or raced in parallel during connection establishment.
@@ -128,11 +128,11 @@ This subsection provides a brief gloassary of key terms related to the architect
 - Protocol Stack: A set of Protocol Instances that are used together to establish connectivity or send and receive Messages.
 - Racing: The attempt to select between multiple Protocol Stacks based on the Selection and Connection Properties communicated by the application, along with any security parameters.
 - Remote Endpoint: A representation of the application's identifier for a peer that can participate in a transport connection.
-- Rendezvous: The action of establishing a peer-to-peer connection with a Remote Endpoint. It simultaneously attempts to initiate a connection to a Remote Endpoint while listening for an incoming connection from that endpoint.
+- Rendezvous: The action of establishing a peer-to-peer connection with a Remote Endpoint.
 - Security Parameters: Parameters that define an application's requirements for authentication and encryption on a Connection.
 - System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.
-- Selection Property: A Transport Property that can set to influence the selection of paths between the Local and Remote Endpoints;
-- Transport Property: A property that expresses requirements, prohibitions, and preferences. 
+- Selection Property: A Transport Property that can set to influence the selection of paths between the Local and Remote Endpoints.
+- Transport Property: A property that expresses requirements, prohibitions, and preferences.
 - Transport Service System: The Transport Service implementation and the Transport Services API.
 
 # API Model {#model}

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -143,7 +143,8 @@ related to one or more transport features {{?RFC8303}}.
 - Socket: The combination of a destination IP address and a destination port number {{?RFC8303}}..
 - System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.
 - Selection Property: A Transport Property that can set to influence the selection of paths between the Local and Remote Endpoints.
-- Transport Feature:  a specific end-to-end feature that the transport layer provides to an application.Transport Property: A property that expresses requirements, prohibitions, and preferences {{?RFC8095}}.
+- Transport Feature:  a specific end-to-end feature that the transport layer provides to an application.
+- Transport Property: A property that expresses requirements, prohibitions, and preferences {{?RFC8095}}.
 - Transport Service:  A set of transport features, without an association to any given framing protocol, that provides a complete service to an application.
 - Transport Service System: The Transport Service implementation and the Transport Services API.
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -115,7 +115,7 @@ This subsection provides a glossary of key terms related to the Transport Servic
 - Application: An entity that uses the transport layer for end-to-end delivery of data across the network {{?RFC8095}}.
 - Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
 - Client: The peer responsible for initiating a transport connection.
-- Clone: A copy of a Connection that forms a part of a Connection Group.
+- Clone: A Connection that was created from another Connection, and forms a part of a Connection Group.
 - Connection: Shared state of two or more Endpoints that persists across Messages that are transmitted and received between these Endpoints {{?RFC8303}}.
 - Connection Group: A set of Connections that shares properties and caches.
 - Connection Property: A Transport Property that can be used to configure protocol-specific options and control per-connection behavior of a Transport Services implementation.

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -123,6 +123,7 @@ This subsection provides a brief gloassary of key terms related to the architect
 - Message:  A unit of data that can be transferred between two endpoints over a transport connection.
 - Message Property: A property than can be used to specify details about Message transmission.
 - Path: A representation of an available set of properties that a Local Endpoint can use to communicate with a Remote Endpoint.
+- Preconnection: an object that repeesents a Connection that has not yet been established.
 - Preference: A preference to prohibit, avoid, ignore prefer or require a specific feature.
 - Protocol Instance: A single instance of one protocol, including any state necessary to establish connectivity or send and receive Messages.
 - Protocol Stack: A set of Protocol Instances that are used together to establish connectivity or send and receive Messages.

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -114,34 +114,34 @@ This subsection provides a glossary of key terms related to the Transport Servic
 
 - Application: An entity that uses the transport layer for end-to-end delivery of data across the network {{?RFC8095}}.
 - Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
-- Client: The peer responsible for initiating a transport connection.
+- Client: The peer responsible for initiating a Connection.
 - Clone: A Connection that was created from another Connection, and forms a part of a Connection Group.
 - Connection: Shared state of two or more endpoints that persists across Messages that are transmitted and received between these Endpoints {{?RFC8303}}.
 - Connection Group: A set of Connections that shares properties and caches.
 - Connection Property: A Transport Property that controls per-Connection behavior of a Transport Services implementation.
-- Endpoint: An identifier for one side of a transport connection (local or remote), such as a hostnames or URL.
-- Equivalent Protocol Stacks: Protocol stacks that can be safely swapped or raced in parallel during connection establishment.
+- Endpoint: An identifier for one side of a Connection (local or remote), such as a hostnames or URL.
+- Equivalent Protocol Stacks: Protocol stacks that can be safely swapped or raced in parallel during establishment of a  Connection.
 - Event: A primitive that is invoked by an endpoint {{?RFC8303}}.
 - Framer: A data translation layer that can be added to a Connection to define how application-layer Messages are transmitted over a transport stack.
-- Local Endpoint: A representation of the application's identifier for itself that it uses for transport connections.
+- Local Endpoint: A representation of the application's identifier for itself that it uses for a Connection.
 - Message:  A unit of data that can be transferred between two Endpoints over a Connection.
 - Message Property: A property than can be used to specify details about Message transmission.
 - Parameter: A value passed between an application and a transport protocol by a primitive {{?RFC8303}}.
 - Path: A representation of an available set of properties that a Local Endpoint can use to communicate with a Remote Endpoint.
 - Peer: An endpoint application party to a Connection.
-- Preconnection: an object that repeesents a Connection that has not yet been established.
+- Preconnection: an object that repesents a Connection that has not yet been established.
 - Preference: A preference to prohibit, avoid, ignore prefer or require a specific transport feature.
 - Primitive: A function call that is used to locally communicate between an application and an endpoint, which is
 related to one or more Transport Features {{?RFC8303}}.
 - Protocol Instance: A single instance of one protocol, including any state necessary to establish connectivity or send and receive Messages.
 - Protocol Stack: A set of Protocol Instances that are used together to establish connectivity or send and receive Messages.
 - Racing: The attempt to select between multiple Protocol Stacks based on the Selection and Connection Properties communicated by the application, along with any security parameters.
-- Remote Endpoint: A representation of the application's identifier for a peer that can participate in a transport connection.
-- Rendezvous: The action of establishing a peer-to-peer connection with a Remote Endpoint.
+- Remote Endpoint: A representation of the application's identifier for a peer that can participate in establishing a Connection.
+- Rendezvous: The action of establishing a peer-to-peer Connection with a Remote Endpoint.
 - Security Parameters: Parameters that define an application's requirements for authentication and encryption on a Connection.
 - Server: The peer responsible for responding to a Connection initiation.
 - Socket: The combination of a destination IP address and a destination port number {{?RFC8303}}..
-- System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.
+- System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during establishment of a Connection.
 - Selection Property: A Transport Property that can set to influence the selection of paths between the Local and Remote Endpoints.
 - Transport Feature:  A specific end-to-end feature that the transport layer provides to an application.
 - Transport Property: A property that expresses requirements, prohibitions and preferences {{?RFC8095}}.

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -112,29 +112,39 @@ they appear in all capitals, as shown here.
 
 This subsection provides a brief gloassary of key terms related to the architecture. These terms ar defined in the relevent sections of this document.
 
+- Application: An entity that uses the transport layer for end-to-end delivery data across the network {{?RFC8095}}.
 - Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
+- Client: The peer responsible for initiating a session.
 - Clone: A copy of a Connection that forms a part of a Connection Group.
-- Connection: An object that can be used to send and receive messages.
+- Connection: Shared state of two or more endpoints that persists across messages that are transmitted and received between these endpoints {{?RFC8303}}.
 - Connection Group: A set of Connections that shares properties and caches.
 - Connection Property: A Transport Property that can be used to configure protocol-specific options and control per-connection behavior of a Transport Services implementation.
 - Endpoint: An identifier for one side of a transport connection.
 - Equivalent Protocol Stacks: Protocol stacks that can be safely swapped or raced in parallel during connection establishment.
+- Event: A primitive that is invoked by a transport endpoint {{?RFC8303}}.
 - Framer: A data translation layer that can be added to a Connection to define how application-layer Messages are transmitted over a transport stack.
 - Local Endpoint: A representation of the application's identifier for itself that it uses for transport connections.
 - Message:  A unit of data that can be transferred between two endpoints over a transport connection.
 - Message Property: A property than can be used to specify details about Message transmission.
+- Parameter: A value passed between an application and a transport protocol by a primitive {{?RFC8303}}.
 - Path: A representation of an available set of properties that a Local Endpoint can use to communicate with a Remote Endpoint.
+- Peer: An endpoint application party to a session.
 - Preconnection: an object that repeesents a Connection that has not yet been established.
 - Preference: A preference to prohibit, avoid, ignore prefer or require a specific feature.
+- Primitive: A function call that is used to locally communicate between an application and a transport endpoint.  A primitive is
+related to one or more transport features {{?RFC8303}}.
 - Protocol Instance: A single instance of one protocol, including any state necessary to establish connectivity or send and receive Messages.
 - Protocol Stack: A set of Protocol Instances that are used together to establish connectivity or send and receive Messages.
 - Racing: The attempt to select between multiple Protocol Stacks based on the Selection and Connection Properties communicated by the application, along with any security parameters.
 - Remote Endpoint: A representation of the application's identifier for a peer that can participate in a transport connection.
 - Rendezvous: The action of establishing a peer-to-peer connection with a Remote Endpoint.
 - Security Parameters: Parameters that define an application's requirements for authentication and encryption on a Connection.
+- Server: The peer responsible for responding to a session initiation.
+- Socket: The combination of a destination IP address and a destination port number {{?RFC8303}}..
 - System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.
 - Selection Property: A Transport Property that can set to influence the selection of paths between the Local and Remote Endpoints.
-- Transport Property: A property that expresses requirements, prohibitions, and preferences.
+- Transport Feature:  a specific end-to-end feature that the transport layer provides to an application.Transport Property: A property that expresses requirements, prohibitions, and preferences {{?RFC8095}}.
+- Transport Service:  A set of transport features, without an association to any given framing protocol, that provides a complete service to an application.
 - Transport Service System: The Transport Service implementation and the Transport Services API.
 
 # API Model {#model}

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -142,7 +142,7 @@ related to one or more Transport Features {{?RFC8303}}.
 - Rendezvous: The action of establishing a peer-to-peer Connection with a Remote Endpoint.
 - Security Parameters: Parameters that define an application's requirements for authentication and encryption on a Connection.
 - Server: The peer responsible for responding to a Connection initiation.
-- Socket: The combination of a destination IP address and a destination port number {{?RFC8303}}..
+- Socket: The combination of a destination IP address and a destination port number {{?RFC8303}}.
 - System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during establishment of a Connection.
 - Selection Property: A Transport Property that can be set to influence the selection of paths between the Local and Remote Endpoints.
 - Transport Feature:  A specific end-to-end feature that the transport layer provides to an application.

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -108,6 +108,33 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 {{!RFC2119}} {{!RFC8174}} when, and only when,
 they appear in all capitals, as shown here.
 
+## Glossary of Key Terms
+
+This subsection provides a brief gloassary of key terms related to the architecture. These terms ar defined in the relevent sections of this document.
+
+- Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
+- Connection: An object that can be used to send and receive messages.
+- Connection Group: A set of Connections that shares properties and caches. 
+- Connection Property: A Transport Property that can be used to configure protocol-specific options and control per-connection behavior of a Transport Services implementation.
+- Endpoint: An identifier for one side of a transport connection.
+- Equivalent Protocol Stacks: Protocol stacks that can be safely swapped or raced in parallel during connection establishment.
+- Framer: A data translation layer that can be added to a Connection to define how application-layer Messages are transmitted over a transport stack.
+- Local Endpoint: A representation of the application's identifier for itself that it uses for transport connections.
+- Message:  A unit of data that can be transferred between two endpoints over a transport connection.
+- Message Property: A property than can be used to specify details about Message transmission.
+- Path: A representation of an available set of properties that a Local Endpoint can use to communicate with a Remote Endpoint.
+- Preference: A preference to prohibit, avoid, ignore prefer or require a specific feature.
+- Protocol Instance: A single instance of one protocol, including any state necessary to establish connectivity or send and receive Messages.
+- Protocol Stack: A set of Protocol Instances that are used together to establish connectivity or send and receive Messages.
+- Racing: The attempt to select between multiple Protocol Stacks based on the Selection and Connection Properties communicated by the application, along with any security parameters.
+- Remote Endpoint: A representation of the application's identifier for a peer that can participate in a transport connection.
+- Rendezvous: The action of establishing a peer-to-peer connection with a Remote Endpoint. It simultaneously attempts to initiate a connection to a Remote Endpoint while listening for an incoming connection from that endpoint.
+- Security Parameters: Parameters that define an application's requirements for authentication and encryption on a Connection.
+- System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.
+- Selection Property: A Transport Property that can set to influence the selection of paths between the Local and Remote Endpoints;
+- Transport Property: A property that expresses requirements, prohibitions, and preferences. 
+- Transport Service System: The Transport Service implementation and the Transport Services API.
+
 # API Model {#model}
 
 The traditional model of using sockets for networking can be represented as follows:
@@ -312,6 +339,7 @@ The following diagram summarizes the top-level concepts in the architecture and 
 ~~~~~~~~~~
 {: #fig-abstractions title="Concepts and Relationships in the Transport Services Architecture"}
 
+The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.  The Cached State is the state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
 
 ## Transport Services API Concepts
 
@@ -477,7 +505,7 @@ This section defines the key concepts of the Transport Services architecture.
 
 * Candidate Protocol Stack: One Protocol Stack that can be used by an application for a Connection,  which there can be several candidates. Candidate Protocol Stacks are identified during the gathering phase ({{gathering}}) and are started during the racing phase ({{racing}}).
 
-* System Policy: Represents the input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks ({{gathering}}) and race the candidates during establishment ({{racing}}). Specific aspects of the System Policy either apply to all Connections or only certain ones, depending on the runtime context and properties of the Connection.
+* System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks ({{gathering}}) and race the candidates during establishment ({{racing}}). Specific aspects of the System Policy either apply to all Connections or only certain ones, depending on the runtime context and properties of the Connection.
 
 * Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously. This can include DNS results, TLS session state, previous success and quality of transport protocols over certain paths, as well as other information.
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -114,6 +114,8 @@ This subsection provides a glossary of key terms related to the Transport Servic
 
 - Application: An entity that uses the transport layer for end-to-end delivery of data across the network {{?RFC8095}}.
 - Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
+- Candidate Path: One path that is available to an application and conforms to the Selection Properties and System Policy during rsacing.
+- Candidate Protocol Stack: One Protocol Stack that can be used by an application for a Connection during racing.
 - Client: The peer responsible for initiating a Connection.
 - Clone: A Connection that was created from another Connection, and forms a part of a Connection Group.
 - Connection: Shared state of two or more endpoints that persists across Messages that are transmitted and received between these Endpoints {{?RFC8303}}.
@@ -125,7 +127,7 @@ This subsection provides a glossary of key terms related to the Transport Servic
 - Framer: A data translation layer that can be added to a Connection to define how application-layer Messages are transmitted over a transport stack.
 - Local Endpoint: A representation of the application's identifier for itself that it uses for a Connection.
 - Message:  A unit of data that can be transferred between two Endpoints over a Connection.
-- Message Property: A property than can be used to specify details about Message transmission.
+- Message Property: A property than can be used to specify details about Message transmission, or obtain details about the transmission after receiving a Message.
 - Parameter: A value passed between an application and a transport protocol by a primitive {{?RFC8303}}.
 - Path: A representation of an available set of properties that a Local Endpoint can use to communicate with a Remote Endpoint.
 - Peer: An endpoint application party to a Connection.
@@ -142,7 +144,7 @@ related to one or more Transport Features {{?RFC8303}}.
 - Server: The peer responsible for responding to a Connection initiation.
 - Socket: The combination of a destination IP address and a destination port number {{?RFC8303}}..
 - System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during establishment of a Connection.
-- Selection Property: A Transport Property that can set to influence the selection of paths between the Local and Remote Endpoints.
+- Selection Property: A Transport Property that can be set to influence the selection of paths between the Local and Remote Endpoints.
 - Transport Feature:  A specific end-to-end feature that the transport layer provides to an application.
 - Transport Property: A property that expresses requirements, prohibitions and preferences {{?RFC8095}}.
 - Transport Service:  A set of transport features, without an association to any given framing protocol, that provides a complete service to an application.
@@ -516,7 +518,7 @@ This section defines the key concepts of the Transport Services architecture.
 
 * Candidate Path: One path that is available to an application and conforms to the Selection Properties and System Policy, of which there can be several. Candidate Paths are identified during the gathering phase ({{gathering}}) and can be used during the racing phase ({{racing}}).
 
-* Candidate Protocol Stack: One Protocol Stack that can be used by an application for a Connection,  which there can be several candidates. Candidate Protocol Stacks are identified during the gathering phase ({{gathering}}) and are started during the racing phase ({{racing}}).
+* Candidate Protocol Stack: One Protocol Stack that can be used by an application for a Connection,  for which there can be several candidates. Candidate Protocol Stacks are identified during the gathering phase ({{gathering}}) and are started during the racing phase ({{racing}}).
 
 * System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks ({{gathering}}) and race the candidates during establishment ({{racing}}). Specific aspects of the System Policy either apply to all Connections or only certain ones, depending on the runtime context and properties of the Connection.
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -354,7 +354,7 @@ The following diagram summarizes the top-level concepts in the architecture and 
 ~~~~~~~~~~
 {: #fig-abstractions title="Concepts and Relationships in the Transport Services Architecture"}
 
-The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.  The Cached State is the state and history that the implementation keeps for each set of associated endpoints that have been used previously.
+The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment. The Cached State is the state and history that the implementation keeps for each set of associated endpoints that have been used previously.
 
 ## Transport Services API Concepts
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -354,7 +354,7 @@ The following diagram summarizes the top-level concepts in the architecture and 
 ~~~~~~~~~~
 {: #fig-abstractions title="Concepts and Relationships in the Transport Services Architecture"}
 
-The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment. The Cached State is the state and history that the implementation keeps for each set of associated endpoints that have been used previously.
+The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment. The Cached State is the state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
 
 ## Transport Services API Concepts
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -110,27 +110,27 @@ they appear in all capitals, as shown here.
 
 ## Glossary of Key Terms
 
-This subsection provides a brief gloassary of key terms related to the architecture. These terms ar defined in the relevent sections of this document.
+This subsection provides a glossary of key terms related to the Transport Services architecture.
 
 - Application: An entity that uses the transport layer for end-to-end delivery data across the network {{?RFC8095}}.
 - Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
-- Client: The peer responsible for initiating a session.
+- Client: The peer responsible for initiating a transport connection.
 - Clone: A copy of a Connection that forms a part of a Connection Group.
 - Connection: Shared state of two or more Endpoints that persists across Messages that are transmitted and received between these Endpoints {{?RFC8303}}.
 - Connection Group: A set of Connections that shares properties and caches.
 - Connection Property: A Transport Property that can be used to configure protocol-specific options and control per-connection behavior of a Transport Services implementation.
 - Endpoint: An identifier for one side of a transport connection.
 - Equivalent Protocol Stacks: Protocol stacks that can be safely swapped or raced in parallel during connection establishment.
-- Event: A primitive that is invoked by a transport endpoint {{?RFC8303}}.
+- Event: A primitive that is invoked by an Endpoint {{?RFC8303}}.
 - Framer: A data translation layer that can be added to a Connection to define how application-layer Messages are transmitted over a transport stack.
 - Local Endpoint: A representation of the application's identifier for itself that it uses for transport connections.
-- Message:  A unit of data that can be transferred between two endpoints over a transport connection.
+- Message:  A unit of data that can be transferred between two Endpoints over a Connection.
 - Message Property: A property than can be used to specify details about Message transmission.
 - Parameter: A value passed between an application and a transport protocol by a primitive {{?RFC8303}}.
 - Path: A representation of an available set of properties that a Local Endpoint can use to communicate with a Remote Endpoint.
-- Peer: An endpoint application party to a session.
+- Peer: An Endpoint application party to a Connection.
 - Preconnection: an object that repeesents a Connection that has not yet been established.
-- Preference: A preference to prohibit, avoid, ignore prefer or require a specific feature.
+- Preference: A preference to prohibit, avoid, ignore prefer or require a specific transport feature.
 - Primitive: A function call that is used to locally communicate between an application and a transport endpoint.  A primitive is
 related to one or more transport features {{?RFC8303}}.
 - Protocol Instance: A single instance of one protocol, including any state necessary to establish connectivity or send and receive Messages.
@@ -139,12 +139,12 @@ related to one or more transport features {{?RFC8303}}.
 - Remote Endpoint: A representation of the application's identifier for a peer that can participate in a transport connection.
 - Rendezvous: The action of establishing a peer-to-peer connection with a Remote Endpoint.
 - Security Parameters: Parameters that define an application's requirements for authentication and encryption on a Connection.
-- Server: The peer responsible for responding to a session initiation.
+- Server: The peer responsible for responding to a Connection initiation.
 - Socket: The combination of a destination IP address and a destination port number {{?RFC8303}}..
 - System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.
 - Selection Property: A Transport Property that can set to influence the selection of paths between the Local and Remote Endpoints.
 - Transport Feature:  A specific end-to-end feature that the transport layer provides to an application.
-- Transport Property: A property that expresses requirements, prohibitions, and preferences {{?RFC8095}}.
+- Transport Property: A property that expresses requirements, prohibitions and preferences {{?RFC8095}}.
 - Transport Service:  A set of transport features, without an association to any given framing protocol, that provides a complete service to an application.
 - Transport Service System: The Transport Service implementation and the Transport Services API.
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -354,7 +354,7 @@ The following diagram summarizes the top-level concepts in the architecture and 
 ~~~~~~~~~~
 {: #fig-abstractions title="Concepts and Relationships in the Transport Services Architecture"}
 
-The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment. The Cached State is the state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
+The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather Candidate Paths and Protocol Stacks and race the candidates when establishing a Connection. The Cached State is the state and history that the implementation keeps for each set of associated Endpoints that have previously been used.
 
 ## Transport Services API Concepts
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -518,7 +518,7 @@ This section defines the key concepts of the Transport Services architecture.
 
 * Candidate Path: One path that is available to an application and conforms to the Selection Properties and System Policy, of which there can be several. Candidate Paths are identified during the gathering phase ({{gathering}}) and can be used during the racing phase ({{racing}}).
 
-* Candidate Protocol Stack: One Protocol Stack that can be used by an application for a Connection,  for which there can be several candidates. Candidate Protocol Stacks are identified during the gathering phase ({{gathering}}) and are started during the racing phase ({{racing}}).
+* Candidate Protocol Stack: One Protocol Stack that can be used by an application for a Connection, for which there can be several candidates. Candidate Protocol Stacks are identified during the gathering phase ({{gathering}}) and are started during the racing phase ({{racing}}).
 
 * System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks ({{gathering}}) and race the candidates during establishment ({{racing}}). Specific aspects of the System Policy either apply to all Connections or only certain ones, depending on the runtime context and properties of the Connection.
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -354,7 +354,7 @@ The following diagram summarizes the top-level concepts in the architecture and 
 ~~~~~~~~~~
 {: #fig-abstractions title="Concepts and Relationships in the Transport Services Architecture"}
 
-The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather Candidate Paths and Protocol Stacks and race the candidates when establishing a Connection. The Cached State is the state and history that the implementation keeps for each set of associated Endpoints that have previously been used.
+The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather Candidate Paths and Protocol Stacks and race the candidates when establishing a Connection. The Cached State is the state and history that the implementation keeps for each set of associated Local and Remote Endpoints that have previously been used.
 
 ## Transport Services API Concepts
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -116,23 +116,23 @@ This subsection provides a glossary of key terms related to the Transport Servic
 - Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
 - Client: The peer responsible for initiating a transport connection.
 - Clone: A Connection that was created from another Connection, and forms a part of a Connection Group.
-- Connection: Shared state of two or more Endpoints that persists across Messages that are transmitted and received between these Endpoints {{?RFC8303}}.
+- Connection: Shared state of two or more endpoints that persists across Messages that are transmitted and received between these Endpoints {{?RFC8303}}.
 - Connection Group: A set of Connections that shares properties and caches.
 - Connection Property: A Transport Property that controls per-Connection behavior of a Transport Services implementation.
-- Endpoint: An identifier for one side of a transport connection.
+- Endpoint: An identifier for one side of a transport connection (local or remote), such as a hostnames or URL.
 - Equivalent Protocol Stacks: Protocol stacks that can be safely swapped or raced in parallel during connection establishment.
-- Event: A primitive that is invoked by an Endpoint {{?RFC8303}}.
+- Event: A primitive that is invoked by an endpoint {{?RFC8303}}.
 - Framer: A data translation layer that can be added to a Connection to define how application-layer Messages are transmitted over a transport stack.
 - Local Endpoint: A representation of the application's identifier for itself that it uses for transport connections.
 - Message:  A unit of data that can be transferred between two Endpoints over a Connection.
 - Message Property: A property than can be used to specify details about Message transmission.
 - Parameter: A value passed between an application and a transport protocol by a primitive {{?RFC8303}}.
 - Path: A representation of an available set of properties that a Local Endpoint can use to communicate with a Remote Endpoint.
-- Peer: An Endpoint application party to a Connection.
+- Peer: An endpoint application party to a Connection.
 - Preconnection: an object that repeesents a Connection that has not yet been established.
 - Preference: A preference to prohibit, avoid, ignore prefer or require a specific transport feature.
-- Primitive: A function call that is used to locally communicate between an application and a transport endpoint.  A primitive is
-related to one or more transport features {{?RFC8303}}.
+- Primitive: A function call that is used to locally communicate between an application and an endpoint, which is
+related to one or more Transport Features {{?RFC8303}}.
 - Protocol Instance: A single instance of one protocol, including any state necessary to establish connectivity or send and receive Messages.
 - Protocol Stack: A set of Protocol Instances that are used together to establish connectivity or send and receive Messages.
 - Racing: The attempt to select between multiple Protocol Stacks based on the Selection and Connection Properties communicated by the application, along with any security parameters.
@@ -352,7 +352,7 @@ The following diagram summarizes the top-level concepts in the architecture and 
 ~~~~~~~~~~
 {: #fig-abstractions title="Concepts and Relationships in the Transport Services Architecture"}
 
-The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.  The Cached State is the state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
+The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.  The Cached State is the state and history that the implementation keeps for each set of associated endpoints that have been used previously.
 
 ## Transport Services API Concepts
 
@@ -399,10 +399,10 @@ The diagram below provides a high-level view of the actions and events during th
 
 ### Endpoint Objects
 
-* Endpoint: An Endpoint represents an identifier for one side of a transport connection.
+* Endpoint: An endpoint represents an identifier for one side of a transport connection.
   Endpoints can be Local Endpoints or Remote Endpoints, and respectively represent an identity
   that the application uses for the source or destination of a connection.
-  An Endpoint can be specified at various levels of abstraction. An Endpoint at a higher level of abstraction (such as a hostname) can be resolved to more concrete identities (such as IP addresses). An endpoint may also represent a multicast group, in which case it selects a multicast transport for communication.
+  An endpoint can be specified at various levels of abstraction. An endpoint at a higher level of abstraction (such as a hostname) can be resolved to more concrete identities (such as IP addresses). An endpoint may also represent a multicast group, in which case it selects a multicast transport for communication.
 
 * Remote Endpoint: The Remote Endpoint represents the application's identifier for a peer that can participate in a transport connection; for example, the combination of a DNS name for the peer and a service name/port.
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -354,8 +354,6 @@ The following diagram summarizes the top-level concepts in the architecture and 
 ~~~~~~~~~~
 {: #fig-abstractions title="Concepts and Relationships in the Transport Services Architecture"}
 
-The Transport Services Implementation includes the Cached State and System Policy. The System Policy provides input from an operating system or other global preferences that can constrain or influence how an implementation will gather Candidate Paths and Protocol Stacks and race the candidates when establishing a Connection. The Cached State is the state and history that the implementation keeps for each set of associated Local and Remote Endpoints that have previously been used.
-
 ## Transport Services API Concepts
 
 Fundamentally, a Transport Services API needs to provide connection objects ({{objects}}) that allow applications to establish communication, and then send and receive data. These could be exposed as handles or referenced objects, depending on the chosen programming language.

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -112,7 +112,7 @@ they appear in all capitals, as shown here.
 
 This subsection provides a glossary of key terms related to the Transport Services architecture.
 
-- Application: An entity that uses the transport layer for end-to-end delivery data across the network {{?RFC8095}}.
+- Application: An entity that uses the transport layer for end-to-end delivery of data across the network {{?RFC8095}}.
 - Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
 - Client: The peer responsible for initiating a transport connection.
 - Clone: A copy of a Connection that forms a part of a Connection Group.

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -116,7 +116,7 @@ This subsection provides a brief gloassary of key terms related to the architect
 - Cached State: The state and history that the implementation keeps for each set of associated Endpoints that have been used previously.
 - Client: The peer responsible for initiating a session.
 - Clone: A copy of a Connection that forms a part of a Connection Group.
-- Connection: Shared state of two or more endpoints that persists across messages that are transmitted and received between these endpoints {{?RFC8303}}.
+- Connection: Shared state of two or more Endpoints that persists across Messages that are transmitted and received between these Endpoints {{?RFC8303}}.
 - Connection Group: A set of Connections that shares properties and caches.
 - Connection Property: A Transport Property that can be used to configure protocol-specific options and control per-connection behavior of a Transport Services implementation.
 - Endpoint: An identifier for one side of a transport connection.
@@ -143,7 +143,7 @@ related to one or more transport features {{?RFC8303}}.
 - Socket: The combination of a destination IP address and a destination port number {{?RFC8303}}..
 - System Policy: The input from an operating system or other global preferences that can constrain or influence how an implementation will gather candidate paths and Protocol Stacks and race the candidates during connection establishment.
 - Selection Property: A Transport Property that can set to influence the selection of paths between the Local and Remote Endpoints.
-- Transport Feature:  a specific end-to-end feature that the transport layer provides to an application.
+- Transport Feature:  A specific end-to-end feature that the transport layer provides to an application.
 - Transport Property: A property that expresses requirements, prohibitions, and preferences {{?RFC8095}}.
 - Transport Service:  A set of transport features, without an association to any given framing protocol, that provides a complete service to an application.
 - Transport Service System: The Transport Service implementation and the Transport Services API.


### PR DESCRIPTION
This provides a glossary. Each glossary item is made from shortening the laster definition in the architecture document. It is intended to avoid a reader being overwhelmed by the new vocabulary. Intended to help address point 1 of  #1091.