### PR TITLE
handling muxed conns. Closes #1139.

### DIFF
--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -485,7 +485,6 @@ establishment procedure for the new stream prior to sending data on it (e.g., wi
 considerations apply to determining stream establishment as apply to establishing a UDP connection, as
 discussed in {{determining-successful-establishment}}.
 
-a new stream of an already established transport Connection and there is no need for a connection establishment
 procedure. This, then, also means that there may not
 be any "establishment" message (like a TCP SYN), but the application can simply start sending
 or receiving.

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -485,7 +485,6 @@ establishment procedure for the new stream prior to sending data on it (e.g., wi
 considerations apply to determining stream establishment as apply to establishing a UDP connection, as
 discussed in {{determining-successful-establishment}}.
 
-Thus, when the Connections that are offered to an application by the Transport Services API are multiplexed,
 the Transport Services implementation can establish a new Connection by simply beginning to use
 a new stream of an already established transport Connection and there is no need for a connection establishment
 procedure. This, then, also means that there may not

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -463,7 +463,7 @@ New connection attempts that involve transmitting data on the network ought not 
 An implementation could choose to let certain handshakes and negotiations complete to gather metrics that influence future connections.
 Keeping additional connections is generally not recommended, because those attempts were slower to connect and may exhibit less desirable properties.
 
-### Determining Successful Establishment {#establish-determine}
+### Determining Successful Establishment {#determining-successful-establishment}
 
 On a per-protocol basis, implementations may select different criteria by which a leaf node is considered to be successfully connected. If the only protocol being used is a transport protocol with a clear handshake, like TCP, then the obvious choice is to declare that node "connected" when the last packet of the three-way handshake has been received. If the only protocol being used is an connectionless protocol, like UDP, the implementation may consider the node fully "connected" the moment it determines a route is present, before sending any packets on the network, see further {{connectionless-racing}}.
 
@@ -485,7 +485,7 @@ the Transport Services implementation can establish a new Connection by using
 a new stream of an already established transport connection. For such streams, there is often no explicit connection
 establishment procedure for the new stream prior to sending data on it (e.g., with SCTP). In this case, the same
 considerations apply to determining stream establishment as apply to establishing a UDP connection, as
-discussed in {{establish-determine}}.
+discussed in {{determining-successful-establishment}}.
 
 Thus, when the Connections that are offered to an application by the Transport Services API are multiplexed,
 the Transport Services implementation can establish a new Connection by simply beginning to use

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -485,7 +485,7 @@ establishment procedure for the new stream prior to sending data on it (e.g., wi
 considerations apply to determining stream establishment as apply to establishing a UDP connection, as
 discussed in {{determining-successful-establishment}}.
 
-procedure. This, then, also means that there may not
+This, then, also means that there may not
 be any "establishment" message (like a TCP SYN), but the application can simply start sending
 or receiving.
 

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -482,7 +482,7 @@ Multiplexing several Connections over a single underlying transport connection r
 
 Thus, when the Connections that are offered to an application by the Transport Services API are multiplexed,
 the Transport Services implementation can establish a new Connection by using
-a new stream of an already established transport connection. For such streams, there is often no explicit connection
+For such streams, there is often no explicit connection
 establishment procedure for the new stream prior to sending data on it (e.g., with SCTP). In this case, the same
 considerations apply to determining stream establishment as apply to establishing a UDP connection, as
 discussed in {{determining-successful-establishment}}.

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -520,7 +520,7 @@ Connectionless protocols such as UDP and UDP-lite generally do not provide the s
 
 ### Implementing listeners for Multiplexed Protocols
 
-Protocols that provide multiplexing of streams can listen for entirely new connections and for new sub-connections (streams of an already existing connection). A new stream arrival of an already existing connection must be presented to the application as a new Connection. This new Connection must be grouped with all other Connections that are multiplexed via the same protocol.
+Protocols that provide multiplexing of streams into a single four-tuple can listen both for entirely new connections (a new HTTP/2 stream on a new TCP connection, for example) and for new sub-connections (a new HTTP/2 stream on an existing connection). If the abstraction of Connection presented to the application is mapped to the multiplexed stream, then for either case the Listener ought to deliver the new Connection objects in the same way. The implementation should allow the application to introspect the Connection Group marked on the Connections to determine the grouping of the multiplexing.
 
 # Implementing Sending and Receiving Data
 
@@ -1050,7 +1050,7 @@ In such cases, the Transport Services system needs to explicitly enable re-use o
 in the socket API).
 
 ConnectionReceived:
-: UDP Multicast Receive Listeners will deliver new Connections once they have received traffic from a new Remote Endpoint.
+: UDP Multicast Receive Listeners will deliver new connections once they have received traffic from a new Remote Endpoint.
 
 Clone:
 : Calling `Clone` on a UDP Multicast Receive Connection creates a new Connection with equivalent parameters. The two Connections are otherwise independent.

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -485,7 +485,7 @@ establishment procedure for the new stream prior to sending data on it (e.g., wi
 considerations apply to determining stream establishment as apply to establishing a UDP connection, as
 discussed in {{determining-successful-establishment}}.
 This, then, also means that there may not
-be any "establishment" message (like a TCP SYN), but the application can simply start sending
+be any "establishment" message (like a TCP SYN).
 or receiving.
 
 

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -485,7 +485,6 @@ establishment procedure for the new stream prior to sending data on it (e.g., wi
 considerations apply to determining stream establishment as apply to establishing a UDP connection, as
 discussed in {{determining-successful-establishment}}.
 
-the Transport Services implementation can establish a new Connection by simply beginning to use
 a new stream of an already established transport Connection and there is no need for a connection establishment
 procedure. This, then, also means that there may not
 be any "establishment" message (like a TCP SYN), but the application can simply start sending

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -484,7 +484,6 @@ For such streams, there is often no explicit connection
 establishment procedure for the new stream prior to sending data on it (e.g., with SCTP). In this case, the same
 considerations apply to determining stream establishment as apply to establishing a UDP connection, as
 discussed in {{determining-successful-establishment}}.
-
 This, then, also means that there may not
 be any "establishment" message (like a TCP SYN), but the application can simply start sending
 or receiving.

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -480,7 +480,6 @@ If all of the leaf nodes fail to connect during racing, i.e. none of the configu
 Multiplexing several Connections over a single underlying transport connection requires that the Connections to be multiplexed belong to the same Connection Group (as is indicated by the application using the Clone call). When the underlying transport connection supports multi-streaming, the Transport Services System can map each Connection in the Connection Group to a different stream.
 
 
-the Transport Services implementation can establish a new Connection by using
 For such streams, there is often no explicit connection
 establishment procedure for the new stream prior to sending data on it (e.g., with SCTP). In this case, the same
 considerations apply to determining stream establishment as apply to establishing a UDP connection, as

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -480,7 +480,6 @@ If all of the leaf nodes fail to connect during racing, i.e. none of the configu
 Multiplexing several Connections over a single underlying transport connection requires that the Connections to be multiplexed belong to the same Connection Group (as is indicated by the application using the Clone call). When the underlying transport connection supports multi-streaming, the Transport Services System can map each Connection in the Connection Group to a different stream.
 
 
-Thus, when the Connections that are offered to an application by the Transport Services API are multiplexed,
 the Transport Services implementation can establish a new Connection by using
 For such streams, there is often no explicit connection
 establishment procedure for the new stream prior to sending data on it (e.g., with SCTP). In this case, the same

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -467,7 +467,7 @@ Keeping additional connections is generally not recommended, because those attem
 
 On a per-protocol basis, implementations may select different criteria by which a leaf node is considered to be successfully connected. If the only protocol being used is a transport protocol with a clear handshake, like TCP, then the obvious choice is to declare that node "connected" when the last packet of the three-way handshake has been received. If the only protocol being used is an connectionless protocol, like UDP, the implementation may consider the node fully "connected" the moment it determines a route is present, before sending any packets on the network, see further {{connectionless-racing}}.
 
-When the Initiate action of a Transport Services API is called without Messages being handed over, depending on the
+When the Initiate action is called without any Messages being sent at the same time, depending on the
 protocols involved, it is not guaranteed that the Remote Endpoint will be notified of this, and hence a passive
 endpoint's application may not receive a ConnectionReceived event until it receives the first Message on the new Connection.
 
@@ -484,7 +484,7 @@ For such streams, there is often no explicit connection
 establishment procedure for the new stream prior to sending data on it (e.g., with SCTP). In this case, the same
 considerations apply to determining stream establishment as apply to establishing a UDP connection, as
 discussed in {{determining-successful-establishment}}.
-This, then, also means that there may not
+This means that there might not
 be any "establishment" message (like a TCP SYN).
 
 

--- a/draft-ietf-taps-impl.md
+++ b/draft-ietf-taps-impl.md
@@ -486,7 +486,6 @@ considerations apply to determining stream establishment as apply to establishin
 discussed in {{determining-successful-establishment}}.
 This, then, also means that there may not
 be any "establishment" message (like a TCP SYN).
-or receiving.
 
 
 ## Handling connectionless protocols {#connectionless-racing}


### PR DESCRIPTION
Pretty much following all suggestions in #1139. I only didn't add the sentence about "Effectively, the streams are an additional protocol layer on top of the transport..." because I don't think this contributes much.