### PR TITLE
Protocol identifiers are strings, listed in the API doc., and shouldn't normally be used

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -869,10 +869,18 @@ multiple aliases set.
 RemoteSpecifier.AddAlias(AlternateRemoteSpecifier)
 ~~~
 
-To scope an alias to a specific transport protocol, an Endpoint can
-specify a protocol specifier. Protocol specifiers are strings. The API
+To scope an alias to a specific transport protocol or protocol stack,
+an Endpoint can specify a protocol specifier. Protocol specifiers
+are strings where slashes separate protocol names. The API
 documentation of a Transport Services system implementation ought to
 contain a list of selectable protocol specifiers.
+
+Normally, an endpoint ought not to request a specific transport protocol or
+protocol stack. The Transport Services system is responsible for mapping
+the API to a specific available transport protocol stack and managing
+the available network interfaces and paths. When specifically needed,
+this automated selection could be over-ridden (e.g., for testing or
+debugging purposes).
 
 ~~~
 AlternateRemoteSpecifier.WithProtocol(QUIC)

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -877,7 +877,6 @@ objects or enumeration values provided by the Transport
 Services API, which will vary based on which protocols are
 implemented in a particular system.
 
-
 ~~~
 AlternateRemoteSpecifier.WithProtocol(QUIC)
 ~~~

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -879,7 +879,7 @@ Normally, an endpoint ought not to request a specific transport protocol or
 protocol stack. The Transport Services system is responsible for mapping
 the API to a specific available transport protocol stack and managing
 the available network interfaces and paths. When specifically needed,
-this automated selection could be over-ridden (e.g., for testing or
+this automated selection could be overridden (e.g., for testing or
 debugging purposes).
 
 ~~~

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -870,7 +870,9 @@ RemoteSpecifier.AddAlias(AlternateRemoteSpecifier)
 ~~~
 
 To scope an alias to a specific transport protocol, an Endpoint can
-specify a protocol specifier.
+specify a protocol specifier. Protocol specifiers are strings. The API
+documentation of a Transport Services system implementation ought to
+contain a list of selectable protocol specifiers.
 
 ~~~
 AlternateRemoteSpecifier.WithProtocol(QUIC)

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -869,18 +869,14 @@ multiple aliases set.
 RemoteSpecifier.AddAlias(AlternateRemoteSpecifier)
 ~~~
 
-To scope an alias to a specific transport protocol or protocol stack,
-an Endpoint can specify a protocol specifier. Protocol specifiers
-are strings where slashes separate protocol names. The API
-documentation of a Transport Services system implementation ought to
-contain a list of selectable protocol specifiers.
+To scope an alias to apply conditionally to a specific transport
+protocol (such as defining an alternate port to use when QUIC
+is selected, as opposed to TCP), an alias Endpoint can be
+associated with a protocol identifier. Protocol identifiers are
+objects or enumeration values provided by the Transport
+Services API, which will vary based on which protocols are
+implemented in a particular system.
 
-Normally, an endpoint ought not to request a specific transport protocol or
-protocol stack. The Transport Services system is responsible for mapping
-the API to a specific available transport protocol stack and managing
-the available network interfaces and paths. When specifically needed,
-this automated selection could be overridden (e.g., for testing or
-debugging purposes).
 
 ~~~
 AlternateRemoteSpecifier.WithProtocol(QUIC)


### PR DESCRIPTION
Closes #1332
Closes #1333
Closes #1361