### PR TITLE
app SHOULD NOT assume that ignoring events is always safe

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -314,7 +314,7 @@ Message Framer that finds message boundaries in a stream. Messages are
 received asynchronously through event handlers registered by the application.
 Errors and other notifications also happen asynchronously on the Connection.
 It is not necessary for an application to handle all events; some events can
-have implementation-specific default handlers. The application ought not
+have implementation-specific default handlers. The application SHOULD NOT
 assume that ignoring events (e.g., errors) is always safe.
 
 


### PR DESCRIPTION
Closes #1307

In a PR where some "should not" became "ought not", this was chosen to be "ought not", but I think Erik is right in #1307 about this one, SHOULD NOT seems better to me.