### PR TITLE
Where do interface names come from?

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -757,6 +757,10 @@ RemoteSpecifier.WithIPAddress(2001:db8:4920:e29d:a420:7461:7073:a)
 LocalSpecifier.WithInterface("en0")
 ~~~
 
+Systems usually offer means to obtain a list of available local interfaces; such means ought to
+be usable by an application to obtain the string to be supplied here. The specifics of these
+means depend on the implementation.
+
 Note that an IPv6 address specified with a scope zone ID (e.g. `fe80::2001:db8%en0`)
 is equivalent to `WithIPAddress` with an unscoped address and `WithInterface ` together.
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -757,9 +757,8 @@ RemoteSpecifier.WithIPAddress(2001:db8:4920:e29d:a420:7461:7073:a)
 LocalSpecifier.WithInterface("en0")
 ~~~
 
-Systems usually offer means to obtain a list of available local interfaces; such means ought to
-be usable by an application to obtain the string to be supplied here. The specifics of these
-means depend on the implementation.
+Systems usually offer means to obtain a list of available local interfaces; when available, these allow the application to obtain the interface name string to supply to this function.
+The details of the system means to enumerate local interfaces are platform-specific.
 
 Note that an IPv6 address specified with a scope zone ID (e.g. `fe80::2001:db8%en0`)
 is equivalent to `WithIPAddress` with an unscoped address and `WithInterface ` together.


### PR DESCRIPTION
Closes #1331

Note: at the interim, we discussed that we could also point at Preconnection.Resolve() as a way to get interface names. I decided against this, however, due to the text that was added there by PR #947: "Note that the set of Local Endpoints returned by Resolve might or might not contain information about all possible local interfaces; it is valid only for a Rendezvous happening at the same time as the resolution. Care ought to be taken in using these values in any other context."

=> This seems to specifically warn against getting interface names for any other purpose with Resolve().