### PR TITLE
s/Transport Services implementation/Transport Services Implementation

### DIFF
--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -136,7 +136,7 @@ This subsection provides a glossary of key terms related to the Transport Servic
 - Connection: Shared state of two or more Endpoints that persists across Messages that are transmitted and received between these Endpoints {{?RFC8303}}. When this document (and other Transport Services documents) use the capitalized "Connection" term, it refers to a Connection object that is being offered by the Transport Services system, as opposed to more generic uses of the word "connection".
 - Connection Context: A set of stored properties across Connections, such as cached protocol state, cached path state, and heuristics, which can include one or more Connection Groups.
 - Connection Group: A set of Connections that share properties and caches.
-- Connection Property: A Transport Property that controls per-Connection behavior of a Transport Services implementation.
+- Connection Property: A Transport Property that controls per-Connection behavior of a Transport Services Implementation.
 - Endpoint: An entity that communicates with one or more other endpoints using a transport protocol.
 - Endpoint Identifier: An identifier that specifies one side of a Connection (local or remote), such as a hostname or URL.
 - Equivalent Protocol Stacks: Protocol Stacks that can be safely swapped or raced in parallel during establishment of a Connection.
@@ -328,7 +328,7 @@ The following example shows Equivalent Protocol Stacks:
 
 A Transport Services Implementation can race different security
 protocols, e.g., if the System Policy is explicitly configured to consider them equivalent.
-A Transport Services implementation SHOULD only race Protocol Stacks where the transport security protocols within the stacks are identical.
+A Transport Services Implementation SHOULD only race Protocol Stacks where the transport security protocols within the stacks are identical.
 To ensure that security protocols are not incorrectly swapped, a Transport Services Implementation MUST only select Protocol Stacks that meet application requirements ({{?RFC8922}}).
 A Transport Services Implementation MUST NOT automatically fall back from secure protocols to insecure protocols, or to weaker versions of secure protocols.
 A Transport Services Implementation MAY allow applications to explicitly specify which versions of a protocol ought to be permitted, e.g., to allow a minimum version of TLS 1.2 in case TLS 1.3 is not available.
@@ -597,7 +597,7 @@ The Transport Services Implementation consists of all objects and protocol insta
 
 ### Candidate Gathering {#gathering}
 
-* Candidate Path Selection: Candidate Path Selection represents the act of choosing one or more paths that are available to use based on the Selection Properties and any available Local and Remote Endpoint Identifiers provided by the application, as well as the policies and heuristics of a Transport Services implementation.
+* Candidate Path Selection: Candidate Path Selection represents the act of choosing one or more paths that are available to use based on the Selection Properties and any available Local and Remote Endpoint Identifiers provided by the application, as well as the policies and heuristics of a Transport Services Implementation.
 
 * Candidate Protocol Selection: Candidate Protocol Selection represents the act of choosing one or more sets of Protocol Stacks that are available to use based on the Transport Properties provided by the application, and the heuristics or policies within the Transport Services Implementation.
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -144,7 +144,7 @@ requirements and network conditions, without requiring changes to the
 applications.  This flexibility enables faster deployment of new features and
 protocols, and can support applications by offering racing and fallback
 mechanisms, which otherwise need to be separately implemented in each application.
-Transport Services implementations are free to take any desired form as long
+Transport Services Implementations are free to take any desired form as long
 as the API specification in this document is honored; a nonprescriptive guide to
 implementing a Transport Services system is available {{?I-D.ietf-taps-impl}}.
 
@@ -571,10 +571,10 @@ the respective protocol has been selected.
 
 Transport Properties are referred to by property names, represented as case-insensitive strings. These names serve two purposes:
 
-- Allowing different components of a Transport Services implementation to pass Transport
+- Allowing different components of a Transport Services Implementation to pass Transport
   Properties, e.g., between a language frontend and a policy manager,
   or as a representation of properties retrieved from a file or other storage.
-- Making the code of different Transport Services implementations look similar.
+- Making the code of different Transport Services Implementations look similar.
   While individual programming languages might preclude strict adherence to the
   aforementioned naming convention (for instance, by prohibiting the use of hyphens
   in symbols), users interacting with multiple implementations will still benefit
@@ -3558,7 +3558,7 @@ Security considerations for these protocols are discussed in the respective spec
 
 The described API is used to exchange information between an application and the Transport Services system. While
 it is not necessarily expected that both systems are implemented by the same authority, it is expected
-that the Transport Services implementation is either provided as a library that is selected by the application
+that the Transport Services Implementation is either provided as a library that is selected by the application
 from a trusted party, or that it is part of the operating system that the application also relies on for
 other tasks.
 
@@ -3593,7 +3593,7 @@ of truncation attacks if applications do not distinguish between partial Message
 
 The Transport Services API explicitly does not require the application to resolve names, though there is
 a tradeoff between early and late binding of addresses to names. Early binding
-allows the Transport Services implementation to reduce Connection setup latency, at the cost
+allows the Transport Services Implementation to reduce Connection setup latency, at the cost
 of potentially limited scope for alternate path discovery during Connection
 establishment, as well as potential additional information leakage about
 application interest when used with a resolution method (such as DNS without


### PR DESCRIPTION
This wasn't uniform: almost everywhere, the -arch draft has "Transport Services Implementation" (and since it's -arch, I assume that this is the right style) whereas the -impl draft has only "Transport Services implementation" and the usage is mixed in -api.